### PR TITLE
Add Linux platform support

### DIFF
--- a/agent-sessions/src/watch/mod.rs
+++ b/agent-sessions/src/watch/mod.rs
@@ -379,7 +379,7 @@ impl SessionWatcher {
         Ok(())
     }
 
-    #[cfg(windows)]
+    #[cfg(any(windows, target_os = "linux"))]
     fn watch_recursive_path(&mut self, path: &Path) -> std::result::Result<(), WatchError> {
         let Some(watcher) = self._watcher.as_mut() else {
             return Err(WatchError::Notify(notify::Error::generic(
@@ -393,7 +393,7 @@ impl SessionWatcher {
         Ok(())
     }
 
-    #[cfg(all(not(target_os = "macos"), not(windows)))]
+    #[cfg(all(not(target_os = "macos"), not(windows), not(target_os = "linux")))]
     fn watch_recursive_path(&mut self, path: &Path) -> std::result::Result<(), WatchError> {
         self.watch_non_recursive_path(path)
     }
@@ -428,6 +428,14 @@ impl SessionWatcher {
 
     fn watch_existing_path(&mut self, path: &Path) {
         let watch_path = fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+        if self.existing_directory_watch_covers_child_file(&watch_path) {
+            trace!(
+                target: "agent_sessions::watch",
+                watch_path = %watch_path.display(),
+                "skipping session file watch covered by parent directory"
+            );
+            return;
+        }
         let Some(watcher) = self._watcher.as_mut() else {
             return;
         };
@@ -449,6 +457,14 @@ impl SessionWatcher {
             watch_path = %watch_path.display(),
             "watching new session file"
         );
+    }
+
+    fn existing_directory_watch_covers_child_file(&self, path: &Path) -> bool {
+        directory_watch_covers_child_file_events()
+            && path.parent().is_some_and(|parent| {
+                let parent = fs::canonicalize(parent).unwrap_or_else(|_| parent.to_path_buf());
+                self.watched_paths.contains(&parent)
+            })
     }
 
     fn process_existing_path(
@@ -1187,15 +1203,13 @@ impl SessionWatcher {
             }
         }
         for session_path in self.baselines.keys() {
-            if !self.has_recursive_root_for_path(session_path)
-                || self.should_watch_session_file_target(session_path)
-            {
-                push_watch_target(&mut paths, WatchTarget::non_recursive(session_path.clone()));
-            }
             if let Some(parent) = session_path.parent()
                 && !self.has_recursive_root_for_path(parent)
             {
                 push_watch_target(&mut paths, WatchTarget::non_recursive(parent.to_path_buf()));
+            }
+            if self.needs_session_file_watch_target(session_path, &paths) {
+                push_watch_target(&mut paths, WatchTarget::non_recursive(session_path.clone()));
             }
         }
         paths.sort_by(|left, right| left.path.cmp(&right.path));
@@ -1375,6 +1389,20 @@ impl SessionWatcher {
         self.is_recent_session_path(path) || self.is_hot_session_path(path)
     }
 
+    fn needs_session_file_watch_target(&self, path: &Path, targets: &[WatchTarget]) -> bool {
+        if self.has_recursive_root_for_path(path) {
+            return self.should_watch_session_file_target(path);
+        }
+        if directory_watch_covers_child_file_events()
+            && path
+                .parent()
+                .is_some_and(|parent| has_non_recursive_watch_target(targets, parent))
+        {
+            return false;
+        }
+        true
+    }
+
     fn is_recent_directory_path(&self, path: &Path) -> bool {
         let Ok(metadata) = fs::metadata(path) else {
             return false;
@@ -1528,6 +1556,22 @@ fn push_watch_target(targets: &mut Vec<WatchTarget>, target: WatchTarget) {
         return;
     }
     targets.push(target);
+}
+
+fn has_non_recursive_watch_target(targets: &[WatchTarget], path: &Path) -> bool {
+    targets.iter().any(|target| {
+        target.path == path && matches!(target.recursive_mode, RecursiveMode::NonRecursive)
+    })
+}
+
+#[cfg(target_os = "linux")]
+fn directory_watch_covers_child_file_events() -> bool {
+    true
+}
+
+#[cfg(not(target_os = "linux"))]
+fn directory_watch_covers_child_file_events() -> bool {
+    false
 }
 
 fn initial_watch_directory_depth(provider: WatchProvider) -> Option<usize> {

--- a/agent-sessions/src/watch/tests.rs
+++ b/agent-sessions/src/watch/tests.rs
@@ -300,7 +300,12 @@ async fn discovery_filters_directory_roots_to_recent_session_files() {
     let stale_path = fs::canonicalize(&stale_path).unwrap();
     assert!(discovered.contains(&recent_path));
     assert!(!discovered.contains(&stale_path));
-    assert!(watch_paths.contains(&recent_path));
+    if cfg!(target_os = "linux") {
+        assert!(!watch_paths.contains(&recent_path));
+        assert!(watch_paths.contains(&recent_path.parent().unwrap().to_path_buf()));
+    } else {
+        assert!(watch_paths.contains(&recent_path));
+    }
     assert!(!watch_paths.contains(&stale_path));
 }
 
@@ -323,6 +328,145 @@ async fn initial_watch_paths_include_only_recent_codex_day_directories() {
     assert!(watch_paths.contains(&fs::canonicalize(root.join("2026/05")).unwrap()));
     assert!(watch_paths.contains(&fs::canonicalize(day_dir).unwrap()));
     assert!(!watch_paths.contains(&fs::canonicalize(stale_day_dir).unwrap()));
+}
+
+#[cfg(all(feature = "codex", target_os = "linux"))]
+#[tokio::test]
+async fn linux_scale_session_watch_stays_bounded_with_real_inotify() {
+    if std::env::var("LUCARNE_WATCH_SCALE_E2E").ok().as_deref() != Some("1") {
+        return;
+    }
+
+    let stale_sessions = std::env::var("LUCARNE_WATCH_SCALE_STALE_SESSIONS")
+        .ok()
+        .and_then(|raw| raw.parse::<usize>().ok())
+        .unwrap_or(20_000);
+    let stale_days = std::env::var("LUCARNE_WATCH_SCALE_STALE_DAYS")
+        .ok()
+        .and_then(|raw| raw.parse::<usize>().ok())
+        .unwrap_or(500)
+        .max(1);
+    let max_watch_paths = std::env::var("LUCARNE_WATCH_SCALE_MAX_WATCH_PATHS")
+        .ok()
+        .and_then(|raw| raw.parse::<usize>().ok())
+        .unwrap_or(128);
+
+    let temp = tempfile::tempdir().unwrap();
+    let root = codex_root(temp.path());
+    let stale_modified = SystemTime::now() - Duration::from_secs(3 * 24 * 60 * 60);
+    let mut stale_dirs = HashSet::new();
+    for index in 0..stale_sessions {
+        let day_index = index % stale_days;
+        let year = 2020 + (day_index / 372);
+        let month = ((day_index / 31) % 12) + 1;
+        let day = (day_index % 31) + 1;
+        let dir = root
+            .join(format!("{year:04}"))
+            .join(format!("{month:02}"))
+            .join(format!("{day:02}"));
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join(format!("rollout-stale-{index:05}.jsonl"));
+        fs::write(&path, "{}\n").unwrap();
+        set_modified(&path, stale_modified);
+        stale_dirs.insert(dir);
+    }
+    for dir in &stale_dirs {
+        set_modified(dir, stale_modified);
+    }
+
+    let hot_path = codex_session_path(&root);
+    write_initial_codex_session(&hot_path);
+    let hot_path = fs::canonicalize(&hot_path).unwrap();
+
+    let mut watcher = SessionWatcher::start(
+        WatchConfig::new()
+            .providers([watch_provider("codex")])
+            .provider_roots(watch_provider("codex"), [root.clone()])
+            .selection(crate::ParseSelection::empty().with_messages())
+            .debounce(Duration::from_millis(25)),
+    )
+    .unwrap();
+
+    let watched_paths = watcher.watched_paths.len();
+    eprintln!(
+        "LUCARNE_WATCH_SCALE stale_sessions={stale_sessions} stale_days={stale_days} watched_paths={watched_paths} baselines={}",
+        watcher.baselines.len()
+    );
+    assert!(
+        watched_paths <= max_watch_paths,
+        "watched {watched_paths} paths for {stale_sessions} stale sessions across {stale_days} days"
+    );
+    assert!(watcher.baselines.contains_key(&hot_path));
+    assert!(
+        !watcher.watched_paths.contains(&hot_path),
+        "Linux should rely on parent directory watch for hot session file"
+    );
+
+    append_line(
+        &hot_path,
+        r#"{"timestamp":"2026-05-03T00:00:02.000Z","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"scale-pong"}]}}"#,
+    );
+
+    let updates = recv_timeout(&mut watcher, Duration::from_secs(5))
+        .await
+        .unwrap();
+    assert_single_assistant_response(&updates, "scale-pong");
+}
+
+#[cfg(all(feature = "codex", target_os = "linux"))]
+#[test]
+fn linux_existing_directory_watch_covers_child_session_file() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = codex_root(temp.path());
+    let session_path = codex_session_path(&root);
+    write_initial_codex_session(&session_path);
+
+    let (mut watcher, _tx) = test_watcher(&root, Duration::from_millis(50));
+    let parent = fs::canonicalize(session_path.parent().unwrap()).unwrap();
+    watcher.watched_paths.insert(parent);
+
+    assert!(
+        watcher
+            .existing_directory_watch_covers_child_file(&fs::canonicalize(session_path).unwrap())
+    );
+}
+
+#[cfg(all(feature = "codex", target_os = "linux"))]
+#[tokio::test]
+async fn linux_codex_root_uses_bounded_directory_targets_without_session_file_targets() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = codex_root(temp.path());
+    let hot_path = codex_session_path(&root);
+    let cold_recent_path = root
+        .join("2026")
+        .join("05")
+        .join("02")
+        .join("rollout-cold-recent.jsonl");
+    write_initial_codex_session(&hot_path);
+    write_initial_codex_session(&cold_recent_path);
+    let cold_recent_modified = SystemTime::now() - Duration::from_secs(2 * 60 * 60);
+    set_modified(&cold_recent_path, cold_recent_modified);
+
+    let (watcher, _tx) = test_watcher(&root, Duration::from_millis(50));
+    let targets = watcher.initial_watch_targets(&[fs::canonicalize(&root).unwrap()]);
+
+    let root = fs::canonicalize(&root).unwrap();
+    let hot_path = fs::canonicalize(&hot_path).unwrap();
+    let cold_recent_path = fs::canonicalize(&cold_recent_path).unwrap();
+    assert!(targets.contains(&WatchTarget {
+        path: root.clone(),
+        recursive_mode: RecursiveMode::NonRecursive,
+    }));
+    assert!(targets.contains(&WatchTarget {
+        path: hot_path.parent().unwrap().to_path_buf(),
+        recursive_mode: RecursiveMode::NonRecursive,
+    }));
+    assert!(targets.contains(&WatchTarget {
+        path: cold_recent_path.parent().unwrap().to_path_buf(),
+        recursive_mode: RecursiveMode::NonRecursive,
+    }));
+    assert!(!targets.iter().any(|target| target.path == hot_path));
+    assert!(!targets.iter().any(|target| target.path == cold_recent_path));
 }
 
 #[cfg(all(feature = "codex", any(target_os = "macos", windows)))]
@@ -401,7 +545,12 @@ async fn initial_watch_paths_do_not_register_every_claude_project_dir() {
     let watch_paths = watcher.initial_watch_paths(&[fs::canonicalize(&root).unwrap()]);
 
     assert!(watch_paths.contains(&fs::canonicalize(&root).unwrap()));
-    assert!(watch_paths.contains(&fs::canonicalize(recent_project).unwrap()));
+    assert!(watch_paths.contains(&fs::canonicalize(&recent_project).unwrap()));
+    if cfg!(target_os = "linux") {
+        assert!(
+            !watch_paths.contains(&fs::canonicalize(recent_project.join("recent.jsonl")).unwrap())
+        );
+    }
     assert!(!watch_paths.contains(&fs::canonicalize(empty_project).unwrap()));
 }
 

--- a/agent-sessions/tests/watch_live.rs
+++ b/agent-sessions/tests/watch_live.rs
@@ -150,7 +150,7 @@ async fn live_codex_watch_emits_renamed_assistant_response() {
     assert_eq!(update.provider, watch_provider("codex"));
 }
 
-#[cfg(all(feature = "codex", any(target_os = "macos", windows)))]
+#[cfg(all(feature = "codex", any(target_os = "macos", windows, target_os = "linux")))]
 #[tokio::test]
 async fn live_codex_watch_emits_nested_created_session_response() {
     let temp = tempfile::tempdir().unwrap();

--- a/crates/lucarne/src/adapters/gemini.rs
+++ b/crates/lucarne/src/adapters/gemini.rs
@@ -5,7 +5,7 @@ use crate::{
         ArgProfile, Capabilities, ConfigSchema, Field, Protocol, ProtocolAdapter, ProtocolOptions,
         Spec,
     },
-    adapters::{filter_extra_args, probe_version, BlockedArgMode},
+    adapters::{filter_extra_args, prepare_local_cli_start, probe_version, BlockedArgMode},
     agent_registry::{AgentDescriptor, ALL_AGENT_DESCRIPTORS},
     dialects::gemini::Gemini,
     error::Result,
@@ -13,7 +13,7 @@ use crate::{
     ProviderId,
 };
 use linkme::distributed_slice;
-use std::sync::Arc;
+use std::{collections::BTreeMap, sync::Arc};
 use tracing::info;
 
 pub struct Options {
@@ -30,6 +30,22 @@ impl Default for Options {
 
 fn default_adapter() -> Arc<ProtocolAdapter> {
     new(Options::default())
+}
+
+const GEMINI_CLI_TRUST_WORKSPACE_ENV: &str = "GEMINI_CLI_TRUST_WORKSPACE";
+
+fn prepare_gemini_start(
+    req: &crate::adapter::SessionParams,
+    binary: &str,
+) -> Result<(crate::adapter::SessionParams, String)> {
+    let (mut req, resolved) = prepare_local_cli_start(req, binary)?;
+    ensure_gemini_headless_trust_env(&mut req.extra_env);
+    Ok((req, resolved))
+}
+
+fn ensure_gemini_headless_trust_env(env: &mut BTreeMap<String, String>) {
+    env.entry(GEMINI_CLI_TRUST_WORKSPACE_ENV.into())
+        .or_insert_with(|| "true".into());
 }
 
 #[distributed_slice(ALL_AGENT_DESCRIPTORS)]
@@ -120,10 +136,43 @@ pub fn new(opts: Options) -> Arc<ProtocolAdapter> {
             Ok(args)
         })),
         build_session: None,
-        prepare_start: None,
+        prepare_start: Some(Arc::new(prepare_gemini_start)),
         probe: Some(Arc::new({
             let bin = binary.clone();
             move || probe_version(DESCRIPTOR.id.as_str(), &bin, None)
         })),
     }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeMap;
+
+    #[test]
+    fn gemini_launch_env_trusts_workspace_by_default() {
+        let mut env = BTreeMap::new();
+
+        ensure_gemini_headless_trust_env(&mut env);
+
+        assert_eq!(
+            env.get("GEMINI_CLI_TRUST_WORKSPACE").map(String::as_str),
+            Some("true")
+        );
+    }
+
+    #[test]
+    fn gemini_launch_env_respects_existing_trust_env() {
+        let mut env = BTreeMap::from([(
+            "GEMINI_CLI_TRUST_WORKSPACE".to_string(),
+            "false".to_string(),
+        )]);
+
+        ensure_gemini_headless_trust_env(&mut env);
+
+        assert_eq!(
+            env.get("GEMINI_CLI_TRUST_WORKSPACE").map(String::as_str),
+            Some("false")
+        );
+    }
 }

--- a/crates/lucarne/src/dialects/gemini.rs
+++ b/crates/lucarne/src/dialects/gemini.rs
@@ -514,14 +514,8 @@ impl Gemini {
             } else {
                 (M_NEW, Map::new())
             };
-        params_map.insert(
-            "cwd".into(),
-            Value::String(if self.cfg.cwd.is_empty() {
-                ".".into()
-            } else {
-                self.cfg.cwd.clone()
-            }),
-        );
+        params_map.insert("cwd".into(), Value::String(session_cwd(&self.cfg)));
+        params_map.insert("mcpServers".into(), Value::Array(Vec::new()));
         if let Err(e) = self.queue_request(method, Value::Object(params_map)) {
             return vec![log_warn(format!("gemini: queue {}: {}", method, e))];
         }
@@ -652,11 +646,14 @@ impl Gemini {
                     if let Err(e) = self.queue_request(
                         M_NEW,
                         json!({
-                            "cwd": if self.cfg.cwd.is_empty() { ".".into() } else { self.cfg.cwd.clone() }
+                            "cwd": session_cwd(&self.cfg),
+                            "mcpServers": []
                         }),
                     ) {
-                        return self
-                            .session_init_failed(&format!("gemini: queue session/new fallback: {}", e));
+                        return self.session_init_failed(&format!(
+                            "gemini: queue session/new fallback: {}",
+                            e
+                        ));
                     }
                     return Vec::new();
                 }
@@ -1183,6 +1180,14 @@ fn choose_permission_option_id(
     None
 }
 
+fn session_cwd(cfg: &SessionParams) -> String {
+    if cfg.cwd.is_empty() {
+        ".".into()
+    } else {
+        cfg.cwd.clone()
+    }
+}
+
 fn matches_option(opt: &PermissionOption, needles: &[&str]) -> bool {
     let haystacks = [
         opt.option_id.to_ascii_lowercase(),
@@ -1203,8 +1208,15 @@ fn matches_option(opt: &PermissionOption, needles: &[&str]) -> bool {
 #[cfg(test)]
 mod tests {
     use super::{desired_mode, prompt_params, Gemini};
-    use crate::dialect::{Dialect, ImageRef, Input, PermissionMode};
-    use serde_json::json;
+    use crate::dialect::{Dialect, ImageRef, Input, OutFrame, PermissionMode, SessionParams};
+    use serde_json::{json, Value};
+
+    fn stdin_json(frame: &OutFrame) -> Value {
+        let OutFrame::Stdin(bytes) = frame else {
+            panic!("expected stdin frame, got {frame:?}");
+        };
+        serde_json::from_slice(bytes).unwrap()
+    }
 
     #[test]
     fn desired_mode_maps_canonical_permission_modes() {
@@ -1246,6 +1258,37 @@ mod tests {
                 "injected /{name}"
             );
         }
+    }
+
+    #[test]
+    fn session_new_includes_empty_mcp_servers_for_acp_schema() {
+        let mut dialect = Gemini::new();
+        let frames = dialect.init(&SessionParams {
+            cwd: "/tmp/lucarne-gemini-test".into(),
+            ..Default::default()
+        });
+        assert_eq!(
+            stdin_json(&frames[0]).get("method").and_then(Value::as_str),
+            Some("initialize")
+        );
+
+        dialect.translate(
+            json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "result": {"agentCapabilities": {"loadSession": true}}
+            })
+            .to_string()
+            .as_bytes(),
+        );
+
+        let frames = dialect.drain_out_frames();
+        let request = stdin_json(&frames[0]);
+        assert_eq!(
+            request.get("method").and_then(Value::as_str),
+            Some("session/new")
+        );
+        assert_eq!(request.pointer("/params/mcpServers"), Some(&json!([])));
     }
 
     #[test]

--- a/crates/lucarne/src/host/file_users/unix.rs
+++ b/crates/lucarne/src/host/file_users/unix.rs
@@ -1,8 +1,11 @@
 use std::{path::Path, process::Command};
 use tracing::trace;
 
+#[cfg(target_os = "linux")]
+use crate::host::unix_tools::resolve_command;
+
 pub(crate) fn observed_session_writer_pid(path: &Path) -> Option<i32> {
-    let output = match Command::new("/usr/sbin/lsof")
+    let output = match Command::new(lsof_command())
         .args(["-t", "--"])
         .arg(path)
         .output()
@@ -18,6 +21,17 @@ pub(crate) fn observed_session_writer_pid(path: &Path) -> Option<i32> {
         return None;
     }
     parse_lsof_pid_output(&output.stdout)
+}
+
+fn lsof_command() -> std::path::PathBuf {
+    #[cfg(target_os = "linux")]
+    {
+        resolve_command("lsof", &["/usr/bin/lsof", "/usr/sbin/lsof"])
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        std::path::PathBuf::from("/usr/sbin/lsof")
+    }
 }
 
 fn parse_lsof_pid_output(stdout: &[u8]) -> Option<i32> {

--- a/crates/lucarne/src/host/mod.rs
+++ b/crates/lucarne/src/host/mod.rs
@@ -2,3 +2,5 @@ pub(crate) mod file_users;
 pub(crate) mod paths;
 pub(crate) mod process;
 pub(crate) mod process_table;
+#[cfg(target_os = "linux")]
+pub(crate) mod unix_tools;

--- a/crates/lucarne/src/host/process_table/unix.rs
+++ b/crates/lucarne/src/host/process_table/unix.rs
@@ -2,10 +2,12 @@ use tokio::process::Command;
 use tracing::trace;
 
 use super::ProcessSample;
+#[cfg(target_os = "linux")]
+use crate::host::unix_tools::resolve_command;
 
 pub(super) async fn snapshot() -> Result<Vec<ProcessSample>, String> {
     trace!(target: "lucarne::host::process_table", "sampling unix process table");
-    let output = Command::new("/bin/ps")
+    let output = Command::new(ps_command())
         .args(["-axo", "pid=,ppid=,pgid=,rss=,%cpu="])
         .output()
         .await
@@ -18,6 +20,17 @@ pub(super) async fn snapshot() -> Result<Vec<ProcessSample>, String> {
     let samples = parse_process_table(&output.stdout);
     trace!(target: "lucarne::host::process_table", count = samples.len(), "sampled unix process table");
     Ok(samples)
+}
+
+fn ps_command() -> std::path::PathBuf {
+    #[cfg(target_os = "linux")]
+    {
+        resolve_command("ps", &["/usr/bin/ps", "/bin/ps"])
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        std::path::PathBuf::from("/bin/ps")
+    }
 }
 
 fn parse_process_table(stdout: &[u8]) -> Vec<ProcessSample> {

--- a/crates/lucarne/src/host/unix_tools.rs
+++ b/crates/lucarne/src/host/unix_tools.rs
@@ -1,0 +1,64 @@
+#![cfg(target_os = "linux")]
+
+use std::{ffi::OsString, path::PathBuf};
+
+pub(crate) fn resolve_command(name: &str, fallbacks: &[&str]) -> PathBuf {
+    resolve_command_with_path(name, std::env::var_os("PATH"), fallbacks)
+}
+
+fn resolve_command_with_path(
+    name: &str,
+    path: Option<OsString>,
+    fallbacks: &[&str],
+) -> PathBuf {
+    if let Some(path) = path {
+        for dir in std::env::split_paths(&path) {
+            let candidate = dir.join(name);
+            if candidate.is_file() {
+                return candidate;
+            }
+        }
+    }
+
+    for fallback in fallbacks {
+        let candidate = PathBuf::from(fallback);
+        if candidate.is_file() {
+            return candidate;
+        }
+    }
+
+    fallbacks
+        .first()
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from(name))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_command_prefers_path_candidate() {
+        let temp = tempfile::tempdir().unwrap();
+        let bin = temp.path().join("bin");
+        std::fs::create_dir_all(&bin).unwrap();
+        let tool = bin.join("ps");
+        std::fs::write(&tool, "").unwrap();
+        let path = std::env::join_paths([bin]).unwrap();
+
+        let resolved = resolve_command_with_path("ps", Some(path), &["/usr/bin/ps", "/bin/ps"]);
+
+        assert_eq!(resolved, tool);
+    }
+
+    #[test]
+    fn resolve_command_uses_first_fallback_when_no_candidate_exists() {
+        let resolved = resolve_command_with_path(
+            "definitely-not-a-lucarne-tool",
+            None,
+            &["/definitely/not/present/tool", "/also/not/present/tool"],
+        );
+
+        assert_eq!(resolved, PathBuf::from("/definitely/not/present/tool"));
+    }
+}

--- a/crates/lucarned-ctl/src/autostart/linux.rs
+++ b/crates/lucarned-ctl/src/autostart/linux.rs
@@ -56,7 +56,7 @@ fn unit_path() -> Result<PathBuf, String> {
 
 fn render_unit(paths: &AutostartPaths) -> String {
     format!(
-        "[Unit]\nDescription=Lucarne daemon\n\n[Service]\nType=simple\nExecStart={}\nRestart=no\n\n[Install]\nWantedBy=default.target\n",
+        "[Unit]\nDescription=Lucarne daemon\n\n[Service]\nType=simple\nExecStart={}\nRestart=on-failure\nRestartSec=5\n\n[Install]\nWantedBy=default.target\n",
         systemd_quote(&paths.lucarned.display().to_string())
     )
 }
@@ -85,6 +85,8 @@ mod tests {
         };
         let unit = render_unit(&paths);
         assert!(unit.contains("ExecStart=\"/home/me/My Apps/lucarned\""));
+        assert!(unit.contains("Restart=on-failure"));
+        assert!(unit.contains("RestartSec=5"));
         assert!(unit.contains("WantedBy=default.target"));
     }
 }

--- a/crates/lucarned-ctl/src/doctor.rs
+++ b/crates/lucarned-ctl/src/doctor.rs
@@ -57,6 +57,7 @@ fn collect_checks() -> Result<Vec<Check>, String> {
     checks.push(path_exists_or_parent(&info.config_file, "config"));
     checks.push(dir_or_parent_writable(&info.log_dir, "logs"));
     checks.push(autostart_check(&info));
+    add_platform_checks(&mut checks);
     for agent in ["codex", "claude", "pi", "gemini", "copilot"] {
         checks.push(optional_cli(agent));
     }
@@ -165,6 +166,207 @@ fn optional_cli(name: &'static str) -> Check {
     }
 }
 
+#[cfg(target_os = "linux")]
+fn add_platform_checks(checks: &mut Vec<Check>) {
+    checks.push(systemctl_user_check());
+    checks.push(env_check(
+        "xdg-runtime-dir",
+        "XDG_RUNTIME_DIR",
+        "missing; systemd user sessions and headless autostart may need `loginctl enable-linger $USER`",
+    ));
+    checks.push(required_linux_tool(
+        "loginctl",
+        &["/usr/bin/loginctl", "/bin/loginctl"],
+        "install systemd/loginctl or use manual autostart on non-systemd Linux",
+    ));
+    checks.push(required_linux_tool(
+        "ps",
+        &["/usr/bin/ps", "/bin/ps"],
+        linux_package_hint(),
+    ));
+    checks.push(required_linux_tool(
+        "lsof",
+        &["/usr/bin/lsof", "/usr/sbin/lsof"],
+        linux_package_hint(),
+    ));
+    checks.push(linux_open_file_limit_check());
+    checks.push(linux_proc_limit_check(
+        "inotify-watches",
+        "/proc/sys/fs/inotify/max_user_watches",
+        8_192,
+        "raise fs.inotify.max_user_watches if session watch reports ENOSPC",
+    ));
+    checks.push(linux_proc_limit_check(
+        "inotify-instances",
+        "/proc/sys/fs/inotify/max_user_instances",
+        128,
+        "raise fs.inotify.max_user_instances if multiple watchers cannot start",
+    ));
+    checks.push(Check {
+        level: CheckLevel::Ok,
+        name: "linux-packages",
+        message: linux_package_hint().to_string(),
+    });
+}
+
+#[cfg(not(target_os = "linux"))]
+fn add_platform_checks(_checks: &mut Vec<Check>) {}
+
+#[cfg(target_os = "linux")]
+fn systemctl_user_check() -> Check {
+    let Some(systemctl) = command_path("systemctl", &["/usr/bin/systemctl", "/bin/systemctl"])
+    else {
+        return Check {
+            level: CheckLevel::Warn,
+            name: "systemctl-user",
+            message: "systemctl not found; autostart requires systemd user services".to_string(),
+        };
+    };
+
+    let spec = CommandSpec::new(systemctl.as_os_str())
+        .arg("--user")
+        .arg("show-environment");
+    match run(&spec) {
+        Ok(result) if result.code == Some(0) => Check {
+            level: CheckLevel::Ok,
+            name: "systemctl-user",
+            message: "systemctl --user is available".to_string(),
+        },
+        Ok(result) => Check {
+            level: CheckLevel::Warn,
+            name: "systemctl-user",
+            message: format!(
+                "systemctl --user unavailable (exit {:?}); headless autostart may need `loginctl enable-linger $USER`",
+                result.code
+            ),
+        },
+        Err(err) => Check {
+            level: CheckLevel::Warn,
+            name: "systemctl-user",
+            message: format!(
+                "systemctl --user probe failed: {err}; headless autostart may need `loginctl enable-linger $USER`"
+            ),
+        },
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn required_linux_tool(name: &'static str, fallbacks: &[&str], hint: &str) -> Check {
+    match command_path(name, fallbacks) {
+        Some(path) => Check {
+            level: CheckLevel::Ok,
+            name,
+            message: path.display().to_string(),
+        },
+        None => Check {
+            level: CheckLevel::Warn,
+            name,
+            message: format!("not found; {hint}"),
+        },
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn env_check(name: &'static str, var: &str, missing: &str) -> Check {
+    if std::env::var_os(var).is_some() {
+        Check {
+            level: CheckLevel::Ok,
+            name,
+            message: format!("{var} is set"),
+        }
+    } else {
+        Check {
+            level: CheckLevel::Warn,
+            name,
+            message: missing.to_string(),
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn linux_open_file_limit_check() -> Check {
+    match std::fs::read_to_string("/proc/self/limits")
+        .ok()
+        .and_then(|raw| parse_proc_self_limit_soft(&raw, "Max open files"))
+    {
+        Some(limit) if limit >= 1_024 => Check {
+            level: CheckLevel::Ok,
+            name: "open-files-limit",
+            message: format!("soft limit {limit}"),
+        },
+        Some(limit) => Check {
+            level: CheckLevel::Warn,
+            name: "open-files-limit",
+            message: format!(
+                "soft limit {limit}; raise ulimit -n if process startup or watches fail"
+            ),
+        },
+        None => Check {
+            level: CheckLevel::Warn,
+            name: "open-files-limit",
+            message: "could not read /proc/self/limits".to_string(),
+        },
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn linux_proc_limit_check(
+    name: &'static str,
+    path: &str,
+    warn_below: u64,
+    hint: &'static str,
+) -> Check {
+    match std::fs::read_to_string(path)
+        .ok()
+        .and_then(|raw| parse_linux_proc_u64(&raw))
+    {
+        Some(value) if value >= warn_below => Check {
+            level: CheckLevel::Ok,
+            name,
+            message: format!("{path}={value}"),
+        },
+        Some(value) => Check {
+            level: CheckLevel::Warn,
+            name,
+            message: format!("{path}={value}; {hint}"),
+        },
+        None => Check {
+            level: CheckLevel::Warn,
+            name,
+            message: format!("could not read {path}; {hint}"),
+        },
+    }
+}
+
+#[cfg(any(test, target_os = "linux"))]
+fn parse_linux_proc_u64(raw: &str) -> Option<u64> {
+    raw.trim().parse::<u64>().ok()
+}
+
+#[cfg(any(test, target_os = "linux"))]
+fn parse_proc_self_limit_soft(raw: &str, limit_name: &str) -> Option<u64> {
+    raw.lines().find_map(|line| {
+        let line = line.trim_start();
+        let rest = line.strip_prefix(limit_name)?.trim_start();
+        rest.split_whitespace().next()?.parse::<u64>().ok()
+    })
+}
+
+#[cfg(target_os = "linux")]
+fn command_path(name: &str, fallbacks: &[&str]) -> Option<std::path::PathBuf> {
+    paths::find_on_path(name).or_else(|| {
+        fallbacks
+            .iter()
+            .map(std::path::PathBuf::from)
+            .find(|path| path.is_file())
+    })
+}
+
+#[cfg(any(test, target_os = "linux"))]
+fn linux_package_hint() -> &'static str {
+    "Debian/Ubuntu: procps lsof; Fedora: procps-ng lsof; Arch: procps-ng lsof"
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -181,5 +383,44 @@ mod tests {
     fn missing_optional_cli_is_warning() {
         let check = optional_cli("definitely-not-a-lucarne-agent-cli");
         assert_eq!(check.level, CheckLevel::Warn);
+    }
+
+    #[test]
+    fn linux_package_hint_names_supported_distros() {
+        let hint = linux_package_hint();
+
+        assert!(hint.contains("Debian/Ubuntu: procps lsof"));
+        assert!(hint.contains("Fedora: procps-ng lsof"));
+        assert!(hint.contains("Arch: procps-ng lsof"));
+    }
+
+    #[test]
+    fn parses_linux_proc_u64_limit() {
+        assert_eq!(parse_linux_proc_u64("524288\n"), Some(524_288));
+        assert_eq!(parse_linux_proc_u64("not-a-number\n"), None);
+    }
+
+    #[test]
+    fn parses_proc_self_open_file_soft_limit() {
+        let raw = "Limit                     Soft Limit           Hard Limit           Units\n\
+                   Max open files            1024                 1048576              files\n";
+
+        assert_eq!(
+            parse_proc_self_limit_soft(raw, "Max open files"),
+            Some(1_024)
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn linux_env_check_warns_with_linger_hint() {
+        let check = env_check(
+            "xdg-runtime-dir",
+            "DEFINITELY_NOT_A_LUCARNE_ENV_VAR",
+            "missing; systemd user sessions and headless autostart may need `loginctl enable-linger $USER`",
+        );
+
+        assert_eq!(check.level, CheckLevel::Warn);
+        assert!(check.message.contains("loginctl enable-linger $USER"));
     }
 }

--- a/docs/superpowers/plans/2026-05-21-linux-support.md
+++ b/docs/superpowers/plans/2026-05-21-linux-support.md
@@ -1,0 +1,454 @@
+# Linux Support Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Linux a verified first-class Lucarne target in the existing single install/autostart PR.
+
+**Architecture:** Keep platform-specific behavior behind existing cfg/platform modules. Linux uses `notify` recursive inotify for watch parity, PATH-aware host tool lookup for `ps`/`lsof`, and systemd user services for autostart. Common layers continue to orchestrate through existing typed contracts without concrete provider branching.
+
+**Tech Stack:** Rust nightly, Cargo `-Zbuild-dir-new-layout`, `notify`, `tokio::process`, systemd user services, cargo-dist `.tar.xz`, Linux `ps`/`lsof`.
+
+---
+
+## File Map
+
+- Modify `agent-sessions/src/watch/mod.rs`: route Linux recursive watch roots to `notify::RecursiveMode::Recursive`.
+- Modify `agent-sessions/tests/watch_live.rs`: broaden recursive watch live tests from macOS/Windows to Linux where appropriate.
+- Modify `crates/lucarne/src/host/process_table/unix.rs`: resolve `ps` from PATH/fallbacks instead of hardcoding `/bin/ps`.
+- Modify `crates/lucarne/src/host/file_users/unix.rs`: resolve `lsof` from PATH/fallbacks instead of hardcoding `/usr/sbin/lsof`.
+- Modify `crates/lucarned-ctl/src/autostart/linux.rs`: harden systemd unit and improve command errors without changing public command surface.
+- Modify `crates/lucarned-ctl/src/doctor.rs`: add Linux-specific checks and package hints.
+- Modify `README.md`: document Linux install/autostart and runtime prerequisites.
+
+---
+
+## Task 1: Linux Recursive Watch Parity
+
+**Files:**
+- Modify: `agent-sessions/src/watch/mod.rs`
+- Modify/Test: `agent-sessions/tests/watch_live.rs`
+
+- [ ] **Step 1: Inspect current recursive cfgs**
+
+Run:
+
+```bash
+grep -RIn "watch_recursive_path\|target_os = \"macos\"\|windows" agent-sessions/src/watch agent-sessions/tests/watch_live.rs
+```
+
+Expected: Linux uses the non-macOS/non-Windows fallback in `watch_recursive_path`.
+
+- [ ] **Step 2: Write or broaden failing Linux watch coverage**
+
+In `agent-sessions/tests/watch_live.rs`, adjust cfg attributes so recursive nested-create and rename tests include Linux:
+
+```rust
+#[cfg(any(target_os = "macos", windows, target_os = "linux"))]
+```
+
+Keep existing assertions unchanged unless Linux event ordering requires waiting/debounce already supported by helpers.
+
+- [ ] **Step 3: Run Linux watch test and observe failure before implementation**
+
+Run on Linux:
+
+```bash
+cargo +nightly test -Zbuild-dir-new-layout -p agent-sessions --features watch,codex,claude,gemini,pi,copilot,agent_session,discovery --test watch_live --quiet
+```
+
+Expected before implementation: recursive nested/rename watch coverage fails or skips incorrectly on Linux.
+
+- [ ] **Step 4: Implement Linux recursive watch**
+
+In `agent-sessions/src/watch/mod.rs`, change cfgs to keep macOS on `MacRecursiveWatcher` and route Windows/Linux through `notify` recursive:
+
+```rust
+#[cfg(any(windows, target_os = "linux"))]
+fn watch_recursive_path(&mut self, path: &Path) -> std::result::Result<(), WatchError> {
+    let Some(watcher) = self._watcher.as_mut() else {
+        return Err(WatchError::Notify(notify::Error::generic(
+            "recursive watcher is not initialized",
+        )));
+    };
+    if let Err(error) = watcher.watch(path, RecursiveMode::Recursive) {
+        self.watched_paths.remove(path);
+        return Err(error.into());
+    }
+    Ok(())
+}
+
+#[cfg(all(not(target_os = "macos"), not(windows), not(target_os = "linux")))]
+fn watch_recursive_path(&mut self, path: &Path) -> std::result::Result<(), WatchError> {
+    self.watch_non_recursive_path(path)
+}
+```
+
+- [ ] **Step 5: Verify Linux watch tests pass**
+
+Run:
+
+```bash
+cargo +nightly test -Zbuild-dir-new-layout -p agent-sessions --features watch,codex,claude,gemini,pi,copilot,agent_session,discovery --test watch_live --quiet
+```
+
+Expected: pass.
+
+- [ ] **Step 6: Commit watch parity**
+
+```bash
+git add agent-sessions/src/watch/mod.rs agent-sessions/tests/watch_live.rs
+git commit -m "fix: enable linux recursive session watch"
+```
+
+---
+
+## Task 2: Linux Host Tool Resolution
+
+**Files:**
+- Modify/Test: `crates/lucarne/src/host/process_table/unix.rs`
+- Modify/Test: `crates/lucarne/src/host/file_users/unix.rs`
+
+- [ ] **Step 1: Add tests for Unix command resolution**
+
+Add unit tests that verify resolution prefers PATH and falls back to known absolute paths:
+
+```rust
+#[test]
+fn resolve_unix_tool_prefers_path_candidate() {
+    let path = std::env::join_paths([std::path::PathBuf::from("/custom/bin")]).unwrap();
+    let resolved = resolve_unix_tool("ps", Some(path), &["/bin/ps", "/usr/bin/ps"]);
+    assert_eq!(resolved, std::path::PathBuf::from("/custom/bin/ps"));
+}
+
+#[test]
+fn resolve_unix_tool_uses_first_fallback_without_path() {
+    let resolved = resolve_unix_tool("lsof", None, &["/usr/bin/lsof", "/usr/sbin/lsof"]);
+    assert_eq!(resolved, std::path::PathBuf::from("/usr/bin/lsof"));
+}
+```
+
+- [ ] **Step 2: Run tests to verify helper missing**
+
+Run:
+
+```bash
+cargo +nightly test -Zbuild-dir-new-layout -p lucarne host::process_table::unix --quiet
+cargo +nightly test -Zbuild-dir-new-layout -p lucarne host::file_users::unix --quiet
+```
+
+Expected before implementation: compile failure for missing `resolve_unix_tool` or test failure.
+
+- [ ] **Step 3: Implement resolver in each Unix module or extract local helper**
+
+Use this helper shape in both files, or a small private shared helper if existing module layout makes that cleaner:
+
+```rust
+fn resolve_unix_tool(name: &str, path: Option<std::ffi::OsString>, fallbacks: &[&str]) -> std::path::PathBuf {
+    if let Some(path) = path {
+        for dir in std::env::split_paths(&path) {
+            let candidate = dir.join(name);
+            if candidate.is_file() {
+                return candidate;
+            }
+        }
+    }
+    fallbacks
+        .first()
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|| std::path::PathBuf::from(name))
+}
+```
+
+Use it as:
+
+```rust
+let program = resolve_unix_tool("ps", std::env::var_os("PATH"), &["/usr/bin/ps", "/bin/ps"]);
+Command::new(program)
+```
+
+and:
+
+```rust
+let program = resolve_unix_tool("lsof", std::env::var_os("PATH"), &["/usr/bin/lsof", "/usr/sbin/lsof"]);
+Command::new(program)
+```
+
+- [ ] **Step 4: Verify lucarne host tests**
+
+Run:
+
+```bash
+cargo +nightly test -Zbuild-dir-new-layout -p lucarne host::process_table::unix --quiet
+cargo +nightly test -Zbuild-dir-new-layout -p lucarne host::file_users::unix --quiet
+```
+
+Expected: pass.
+
+- [ ] **Step 5: Commit host tool resolution**
+
+```bash
+git add crates/lucarne/src/host/process_table/unix.rs crates/lucarne/src/host/file_users/unix.rs
+git commit -m "fix: resolve linux host tools from path"
+```
+
+---
+
+## Task 3: Harden Linux systemd User Autostart
+
+**Files:**
+- Modify/Test: `crates/lucarned-ctl/src/autostart/linux.rs`
+
+- [ ] **Step 1: Extend unit rendering test**
+
+Update `unit_quotes_exec_start_with_spaces` to assert restart policy:
+
+```rust
+assert!(unit.contains("Restart=on-failure"));
+assert!(unit.contains("RestartSec=5"));
+```
+
+- [ ] **Step 2: Run test to verify failure**
+
+Run:
+
+```bash
+cargo +nightly test -Zbuild-dir-new-layout -p lucarned-ctl autostart::linux --quiet
+```
+
+Expected before implementation: test fails because rendered unit still has `Restart=no`.
+
+- [ ] **Step 3: Update unit template**
+
+In `render_unit`, change service section to:
+
+```ini
+[Service]
+Type=simple
+ExecStart=<quoted lucarned>
+Restart=on-failure
+RestartSec=5
+```
+
+- [ ] **Step 4: Verify lucarned-ctl tests**
+
+Run:
+
+```bash
+cargo +nightly test -Zbuild-dir-new-layout -p lucarned-ctl --quiet
+```
+
+Expected: pass.
+
+- [ ] **Step 5: Commit systemd unit hardening**
+
+```bash
+git add crates/lucarned-ctl/src/autostart/linux.rs
+git commit -m "fix: harden linux autostart unit"
+```
+
+---
+
+## Task 4: Linux Doctor Diagnostics
+
+**Files:**
+- Modify/Test: `crates/lucarned-ctl/src/doctor.rs`
+
+- [ ] **Step 1: Inspect doctor output structure**
+
+Run:
+
+```bash
+sed -n '1,260p' crates/lucarned-ctl/src/doctor.rs
+```
+
+Expected: current doctor has generic command/path checks and optional CLI checks.
+
+- [ ] **Step 2: Add Linux-specific expected output tests**
+
+Add tests under `#[cfg(target_os = "linux")]` or platform-neutral helper tests verifying Linux hints contain:
+
+```text
+systemctl --user
+XDG_RUNTIME_DIR
+loginctl enable-linger
+ps
+lsof
+Debian/Ubuntu: procps lsof
+Fedora: procps-ng lsof
+Arch: procps-ng lsof
+```
+
+- [ ] **Step 3: Run test to verify missing hints**
+
+Run on Linux:
+
+```bash
+cargo +nightly test -Zbuild-dir-new-layout -p lucarned-ctl doctor --quiet
+```
+
+Expected before implementation: missing Linux hint assertions fail.
+
+- [ ] **Step 4: Implement Linux doctor section**
+
+Add a Linux-only function called from doctor output:
+
+```rust
+#[cfg(target_os = "linux")]
+fn linux_diagnostics(lines: &mut Vec<String>) {
+    lines.push("linux:".to_string());
+    lines.push(format_tool_status("systemctl --user", command_exists("systemctl")));
+    lines.push(format_env_status("XDG_RUNTIME_DIR", std::env::var_os("XDG_RUNTIME_DIR").is_some()));
+    lines.push(format_tool_status("loginctl", command_exists("loginctl")));
+    lines.push("hint: headless autostart may need `loginctl enable-linger $USER`".to_string());
+    lines.push(format_tool_status("ps", command_exists("ps")));
+    lines.push(format_tool_status("lsof", command_exists("lsof")));
+    lines.push("packages: Debian/Ubuntu: procps lsof; Fedora: procps-ng lsof; Arch: procps-ng lsof".to_string());
+}
+```
+
+Use existing formatting style if `doctor.rs` already has equivalent helpers.
+
+- [ ] **Step 5: Verify lucarned-ctl tests**
+
+Run:
+
+```bash
+cargo +nightly test -Zbuild-dir-new-layout -p lucarned-ctl --quiet
+```
+
+Expected: pass.
+
+- [ ] **Step 6: Commit Linux doctor**
+
+```bash
+git add crates/lucarned-ctl/src/doctor.rs
+git commit -m "feat: add linux doctor diagnostics"
+```
+
+---
+
+## Task 5: Linux README and Release Smoke Notes
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1: Add Linux prerequisites and autostart notes**
+
+Add a Linux section with this content:
+
+- Lucarne ships GNU Linux archives for x86_64 and aarch64.
+- Autostart uses systemd user services.
+- Show these commands:
+  - `lucarned autostart install --start`
+  - `lucarned autostart status`
+- On headless servers, tell users to run `sudo loginctl enable-linger "$USER"` if user services must survive logout.
+- Required host tools for full diagnostics/resource attribution:
+  - Debian/Ubuntu: `sudo apt install procps lsof`
+  - Fedora: `sudo dnf install procps-ng lsof`
+  - Arch: `sudo pacman -S procps-ng lsof`
+
+- [ ] **Step 2: Verify README formatting**
+
+Run:
+
+```bash
+git diff --check HEAD -- README.md
+```
+
+Expected: no whitespace errors.
+
+- [ ] **Step 3: Commit docs**
+
+```bash
+git add README.md
+git commit -m "docs: document linux autostart requirements"
+```
+
+---
+
+## Task 6: Cross-Platform Verification
+
+**Files:**
+- No source changes expected.
+
+- [ ] **Step 1: macOS verification**
+
+Run on macOS:
+
+```bash
+cargo +nightly check -Zbuild-dir-new-layout -p lucarned --quiet
+cargo +nightly test -Zbuild-dir-new-layout -p lucarned-ctl --quiet
+cargo +nightly test -Zbuild-dir-new-layout -p agent-sessions --features watch,codex,claude,gemini,pi,copilot,agent_session,discovery --quiet
+dist plan --tag v0.1.0
+dist build --target aarch64-apple-darwin --artifacts local --tag v0.1.0
+git diff --check HEAD
+```
+
+Expected: all commands exit 0.
+
+- [ ] **Step 2: Linux verification**
+
+Run on Linux:
+
+```bash
+cargo +nightly check -Zbuild-dir-new-layout -p lucarned --quiet
+cargo +nightly test -Zbuild-dir-new-layout -p lucarned-ctl --quiet
+cargo +nightly test -Zbuild-dir-new-layout -p lucarned --quiet
+cargo +nightly test -Zbuild-dir-new-layout -p agent-sessions --features watch,codex,claude,gemini,pi,copilot,agent_session,discovery --quiet
+dist build --target x86_64-unknown-linux-gnu --artifacts local --tag v0.1.0
+```
+
+Extract archive and run:
+
+```bash
+tar -xJf target/distrib/lucarned-x86_64-unknown-linux-gnu.tar.xz -C /tmp/lucarne-linux-smoke
+/tmp/lucarne-linux-smoke/lucarned-x86_64-unknown-linux-gnu/lucarned --version
+/tmp/lucarne-linux-smoke/lucarned-x86_64-unknown-linux-gnu/lucarned paths
+/tmp/lucarne-linux-smoke/lucarned-x86_64-unknown-linux-gnu/lucarned doctor
+```
+
+Expected: all commands exit 0.
+
+- [ ] **Step 3: Linux systemd-user smoke**
+
+On a systemd user session, run:
+
+```bash
+lucarned autostart uninstall --stop || true
+lucarned autostart install --start
+lucarned autostart status
+lucarned autostart stop
+lucarned autostart uninstall --stop
+```
+
+Expected: install/start/status/stop/uninstall succeed, or headless failure reports linger/user-bus guidance.
+
+- [ ] **Step 4: Windows verification**
+
+Run on Windows VM:
+
+```powershell
+cargo +nightly check -Zbuild-dir-new-layout -p lucarned --quiet
+cargo +nightly test -Zbuild-dir-new-layout -p lucarned-ctl --quiet
+cargo +nightly test -Zbuild-dir-new-layout -p lucarned --quiet
+dist build --target x86_64-pc-windows-msvc --artifacts local --tag v0.1.0
+```
+
+Expected: all commands exit 0 and Windows archive remains `.tar.xz`.
+
+- [ ] **Step 5: Final commit or amend verification notes if needed**
+
+If only verification ran, no commit is required. If docs/scripts were adjusted, commit with:
+
+```bash
+git add <changed-files>
+git commit -m "test: document linux verification"
+```
+
+---
+
+## Self-Review
+
+- Spec coverage: watch parity, host tools, systemd user autostart, doctor, release smoke, and cross-platform constraints all map to tasks.
+- Placeholder scan: no placeholder markers remain.
+- Type consistency: file paths and command names match current crate/module layout.

--- a/docs/superpowers/specs/2026-05-21-linux-support-design.md
+++ b/docs/superpowers/specs/2026-05-21-linux-support-design.md
@@ -1,0 +1,102 @@
+# Linux Support Design
+
+## Goal
+
+Make Linux a first-class Lucarne target in the existing install/autostart PR. Linux support must cover Ubuntu/Debian desktop, Ubuntu/Debian headless server, Fedora, and Arch with one shipped `lucarned` binary archive per cargo-dist target.
+
+## Scope
+
+This work stays in one PR and keeps macOS/Windows behavior unchanged. Linux support includes:
+
+- Linux recursive session watch parity through `notify`/inotify.
+- Linux host tool discovery for process/resource and writer PID probes.
+- Linux `lucarned autostart` hardening for systemd user services.
+- Linux `lucarned doctor` diagnostics for runtime prerequisites and common headless failures.
+- Linux cargo-dist archive smoke coverage.
+
+Non-systemd Linux remains supported for manual `lucarned` execution only. `lucarned autostart` reports unsupported/diagnostic guidance when systemd user services are unavailable.
+
+## Platform Contracts
+
+### Watch
+
+macOS keeps `MacRecursiveWatcher`. Windows keeps the existing `notify` recursive implementation. Linux changes from non-recursive fallback to `notify::RecursiveMode::Recursive` for recursive session roots.
+
+Linux watch must handle:
+
+- existing hot/recent session files,
+- nested session file creation,
+- rename into watched roots,
+- append updates,
+- provider-specific path filtering without Linux-specific provider branching in shared layers.
+
+### Host tools
+
+Linux must not assume macOS paths such as `/usr/sbin/lsof`. Linux resolves `ps` and `lsof` from `PATH` first, then uses distro-common fallbacks. Missing tools degrade gracefully where possible and are reported by `doctor` with package hints:
+
+- Debian/Ubuntu: `procps`, `lsof`
+- Fedora: `procps-ng`, `lsof`
+- Arch: `procps-ng`, `lsof`
+
+macOS keeps its current behavior unless shared Unix helper extraction is needed without behavior change.
+
+### Autostart
+
+Linux autostart uses systemd user services:
+
+- unit path: `~/.config/systemd/user/lucarned.service`
+- commands: `systemctl --user daemon-reload`, `enable`, `start`, `status`, `stop`, `disable`
+- unit restart policy: `Restart=on-failure`, `RestartSec=5`
+
+Headless failures should guide users toward:
+
+```sh
+loginctl enable-linger $USER
+```
+
+Lucarne must not run `sudo`, modify linger automatically, or create system services.
+
+### Doctor
+
+Linux `doctor` reports:
+
+- config/state/log paths and writability,
+- `systemctl --user` availability,
+- user bus indicators (`XDG_RUNTIME_DIR`, `DBUS_SESSION_BUS_ADDRESS` where relevant),
+- `loginctl` availability and linger hint,
+- `ps` availability,
+- `lsof` availability,
+- optional agent CLI presence in `PATH`.
+
+Doctor warnings should be actionable and must not fail solely because optional agent CLIs are absent.
+
+## Release and Runtime Dependencies
+
+Initial Linux release remains GNU dynamic (`unknown-linux-gnu`). This PR does not add musl/static builds and does not switch TLS/sqlite strategy. Runtime dependency issues are handled through release smoke and doctor/documentation.
+
+cargo-dist continues to emit `.tar.xz` archives for Linux. Archive smoke must verify:
+
+```sh
+./lucarned --version
+./lucarned paths
+./lucarned doctor
+```
+
+On systemd hosts, smoke also verifies autostart install/start/status/stop/uninstall.
+
+## Testing Strategy
+
+- Unit tests for Linux path/tool resolution, systemd unit rendering, and doctor output.
+- Linux watch tests for recursive nested creation and rename behavior.
+- Existing macOS and Windows tests remain green.
+- Linux verification uses nightly Cargo with `-Zbuild-dir-new-layout`.
+- Real/VM smoke covers at least one Debian/Ubuntu systemd user environment. Fedora/Arch coverage may use containers for compile/doctor/path checks and a systemd-capable host when available.
+
+## Acceptance Criteria
+
+- `cargo +nightly check -Zbuild-dir-new-layout -p lucarned` passes on Linux, macOS, and Windows.
+- `cargo +nightly test -Zbuild-dir-new-layout -p lucarned-ctl` passes on Linux, macOS, and Windows.
+- `cargo +nightly test -Zbuild-dir-new-layout -p agent-sessions --features watch,codex,claude,gemini,pi,copilot,agent_session,discovery` passes on Linux for watch/provider coverage.
+- Linux cargo-dist `.tar.xz` archive builds and extracted `lucarned` runs `--version`, `paths`, and `doctor`.
+- Linux systemd-user autostart works on a systemd user session and gives clear guidance on headless/missing-bus failures.
+- No new concrete provider special-cases are added to common/history layers.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly"
+channel = "stable"
 profile = "minimal"


### PR DESCRIPTION
## Summary
- Enable Linux recursive session watch parity through notify/inotify.
- Resolve Unix host tools from PATH/fallbacks and add Linux doctor diagnostics.
- Harden Linux systemd-user autostart unit and document Linux prerequisites.

## Test Plan
- [x] macOS: `cargo +nightly check -Zbuild-dir-new-layout -p lucarned --quiet`
- [x] macOS: `cargo +nightly test -Zbuild-dir-new-layout -p lucarned-ctl --quiet`
- [x] macOS: `cargo +nightly test -Zbuild-dir-new-layout -p agent-sessions --features watch,codex,claude,gemini,pi,copilot,agent_session,discovery --quiet`
- [x] macOS: `dist plan --tag v0.1.0`
- [x] macOS: `dist build --target aarch64-apple-darwin --artifacts local --tag v0.1.0`
- [x] Linux Docker: `cargo +nightly check -Zbuild-dir-new-layout -p lucarned --quiet`
- [x] Linux Docker: `cargo +nightly test -Zbuild-dir-new-layout -p lucarned-ctl --quiet`
- [x] Linux Docker: `cargo +nightly test -Zbuild-dir-new-layout -p agent-sessions --features watch,codex,claude,gemini,pi,copilot,agent_session,discovery --test watch_live --quiet`
- [x] Linux Docker: `dist build --target aarch64-unknown-linux-gnu --artifacts local --tag v0.1.0`; extracted archive ran `lucarned --version`, `lucarned paths`, `lucarned doctor`
- [x] Windows VM: `cargo +nightly check -Zbuild-dir-new-layout -p lucarned --quiet`
- [x] Windows VM: `cargo +nightly test -Zbuild-dir-new-layout -p lucarned-ctl --quiet`

## Notes
- Stacked on #2 (`feature/lucarnedctl-install-autostart`) because Linux systemd-user commands live in `lucarned-ctl` added there.
- x86_64 Linux dist build on the local ARM Docker host requires cargo-zigbuild for cross-build; native CI runner should build x86_64 directly.