### PR TITLE
feat: add update awareness notifications

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1468,6 +1468,13 @@ dependencies = [
 [[package]]
 name = "lucarned-ctl"
 version = "0.2.3"
+dependencies = [
+ "reqwest",
+ "semver",
+ "serde",
+ "serde_json",
+ "tokio",
+]
 
 [[package]]
 name = "md-5"

--- a/crates/lucarne-adapter/src/lib.rs
+++ b/crates/lucarne-adapter/src/lib.rs
@@ -9,7 +9,7 @@ use async_trait::async_trait;
 use lucarne::LucarneCore;
 use serde::Deserialize;
 use tokio::{
-    sync::{mpsc, watch},
+    sync::{broadcast, mpsc, watch},
     task::{AbortHandle, JoinHandle},
 };
 use tracing::{debug, info, warn};
@@ -276,6 +276,54 @@ pub struct GlobalConfigUpdate {
     pub notifications: bool,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SystemNotification {
+    UpdateAvailable(SystemUpdateNotification),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SystemUpdateNotification {
+    pub current_version: String,
+    pub latest_version: String,
+    pub release_name: String,
+    pub release_url: String,
+    pub published_at: Option<String>,
+    pub body_markdown: String,
+    pub install_hint: String,
+}
+
+#[derive(Clone)]
+pub struct SystemNotificationBus {
+    tx: broadcast::Sender<SystemNotification>,
+}
+
+pub struct SystemNotificationReceiver {
+    rx: broadcast::Receiver<SystemNotification>,
+}
+
+impl SystemNotificationBus {
+    pub fn new(capacity: usize) -> Self {
+        let (tx, _rx) = broadcast::channel(capacity.max(1));
+        Self { tx }
+    }
+
+    pub fn subscribe(&self) -> SystemNotificationReceiver {
+        SystemNotificationReceiver {
+            rx: self.tx.subscribe(),
+        }
+    }
+
+    pub fn send(&self, notification: SystemNotification) -> usize {
+        self.tx.send(notification).unwrap_or(0)
+    }
+}
+
+impl SystemNotificationReceiver {
+    pub async fn recv(&mut self) -> Result<SystemNotification, broadcast::error::RecvError> {
+        self.rx.recv().await
+    }
+}
+
 pub trait GlobalConfigPersistence: Send + Sync {
     fn persist_global_config(&self, update: GlobalConfigUpdate) -> AdapterResult<()>;
 }
@@ -286,6 +334,7 @@ pub struct AdapterContext {
     pub config: Arc<AdapterConfig>,
     pub shutdown: watch::Receiver<bool>,
     pub http_client: reqwest::Client,
+    pub system_notifications: SystemNotificationBus,
     pub global_config_persistence: Option<Arc<dyn GlobalConfigPersistence>>,
 }
 
@@ -1118,6 +1167,51 @@ mod tests {
             source.contains("pub http_client: reqwest::Client"),
             "AdapterContext must carry one cloned reqwest::Client for all adapters"
         );
+        assert!(
+            source.contains("pub system_notifications: SystemNotificationBus"),
+            "AdapterContext must carry generic system notification bus"
+        );
+    }
+
+    #[tokio::test]
+    async fn system_notification_bus_fans_out_to_subscribers() {
+        let bus = SystemNotificationBus::new(16);
+        let mut first = bus.subscribe();
+        let mut second = bus.subscribe();
+        let notification = test_update_notification("0.2.0");
+
+        assert_eq!(bus.send(notification.clone()), 2);
+        assert_eq!(first.recv().await.unwrap(), notification);
+        assert_eq!(second.recv().await.unwrap(), notification);
+    }
+
+    #[test]
+    fn system_notification_bus_send_without_receivers_returns_zero() {
+        let bus = SystemNotificationBus::new(16);
+
+        assert_eq!(bus.send(test_update_notification("0.2.0")), 0);
+    }
+
+    #[tokio::test]
+    async fn system_notification_bus_clamps_zero_capacity() {
+        let bus = SystemNotificationBus::new(0);
+        let mut receiver = bus.subscribe();
+        let notification = test_update_notification("0.2.0");
+
+        assert_eq!(bus.send(notification.clone()), 1);
+        assert_eq!(receiver.recv().await.unwrap(), notification);
+    }
+
+    fn test_update_notification(latest_version: &str) -> SystemNotification {
+        SystemNotification::UpdateAvailable(SystemUpdateNotification {
+            current_version: "0.1.0".to_string(),
+            latest_version: latest_version.to_string(),
+            release_name: "Lucarne 0.2.0".to_string(),
+            release_url: "https://example.invalid/release".to_string(),
+            published_at: Some("2026-05-21T00:00:00Z".to_string()),
+            body_markdown: "Update available".to_string(),
+            install_hint: "Run installer".to_string(),
+        })
     }
 
     #[test]
@@ -1304,6 +1398,7 @@ channels:
                         config: Arc::new(AdapterConfig::default()),
                         shutdown: shutdown_rx,
                         http_client: reqwest::Client::new(),
+                        system_notifications: SystemNotificationBus::new(16),
                         global_config_persistence: None,
                     })
                     .await
@@ -1344,6 +1439,7 @@ channels:
                     config: Arc::new(AdapterConfig::default()),
                     shutdown: shutdown_rx,
                     http_client: reqwest::Client::new(),
+                    system_notifications: SystemNotificationBus::new(16),
                     global_config_persistence: None,
                 },
                 options,
@@ -1373,6 +1469,7 @@ channels:
                     config: Arc::new(AdapterConfig::default()),
                     shutdown: shutdown_rx,
                     http_client: reqwest::Client::new(),
+                    system_notifications: SystemNotificationBus::new(16),
                     global_config_persistence: None,
                 },
                 AdapterSupervisorOptions::for_tests(),
@@ -1416,6 +1513,7 @@ channels:
                     config: Arc::new(AdapterConfig::default()),
                     shutdown: shutdown_rx,
                     http_client: reqwest::Client::new(),
+                    system_notifications: SystemNotificationBus::new(16),
                     global_config_persistence: None,
                 },
                 AdapterSupervisorOptions::for_tests(),
@@ -1456,6 +1554,7 @@ channels:
                     config: Arc::new(AdapterConfig::default()),
                     shutdown: shutdown_rx,
                     http_client: reqwest::Client::new(),
+                    system_notifications: SystemNotificationBus::new(16),
                     global_config_persistence: None,
                 },
                 AdapterSupervisorOptions::for_tests(),
@@ -1492,6 +1591,7 @@ channels:
                     config: Arc::new(AdapterConfig::default()),
                     shutdown: shutdown_rx,
                     http_client: reqwest::Client::new(),
+                    system_notifications: SystemNotificationBus::new(16),
                     global_config_persistence: None,
                 },
                 AdapterSupervisorOptions::for_tests(),
@@ -1533,6 +1633,7 @@ channels:
                     config: Arc::new(AdapterConfig::default()),
                     shutdown: shutdown_rx,
                     http_client: reqwest::Client::new(),
+                    system_notifications: SystemNotificationBus::new(16),
                     global_config_persistence: None,
                 },
                 AdapterSupervisorOptions::for_tests(),

--- a/crates/lucarne-telegram/src/adapter.rs
+++ b/crates/lucarne-telegram/src/adapter.rs
@@ -4,6 +4,7 @@ use async_trait::async_trait;
 use lucarne::LucarneCore;
 use lucarne_adapter::{
     AdapterConfig, AdapterContext, AdapterError, AdapterPlugin, AdapterResult, AdapterTask,
+    SystemNotificationBus, SystemNotificationReceiver,
 };
 use tracing::{debug, info};
 
@@ -48,6 +49,7 @@ impl AdapterPlugin for TelegramAdapterPlugin {
         let core = Arc::clone(&ctx.core);
         let http_client = ctx.http_client.clone();
         let global_config_persistence = ctx.global_config_persistence.clone();
+        let system_notifications = ctx.system_notifications.subscribe();
         info!(
             target: "lucarne_telegram::adapter",
             entry_chat_id = config.entry_chat_id,
@@ -56,11 +58,12 @@ impl AdapterPlugin for TelegramAdapterPlugin {
         );
         lucarne::memory_profile_snapshot!("lucarne_telegram.adapter.spawn.before_task_spawn");
         Ok(AdapterTask::spawn(self.id(), async move {
-            run_telegram_adapter_with_client_and_global_config_persistence(
+            run_telegram_adapter_with_client_and_global_config_persistence_and_system_notifications(
                 core,
                 config,
                 http_client,
                 global_config_persistence,
+                system_notifications,
             )
             .await
             .map_err(|err| AdapterError::message(err.to_string()))
@@ -117,6 +120,28 @@ pub async fn run_telegram_adapter_with_client_and_global_config_persistence(
     http_client: reqwest::Client,
     global_config_persistence: Option<Arc<dyn lucarne_adapter::GlobalConfigPersistence>>,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let noop_system_notifications = SystemNotificationBus::new(1);
+    let system_notifications = noop_system_notifications.subscribe();
+    let result =
+        run_telegram_adapter_with_client_and_global_config_persistence_and_system_notifications(
+            core,
+            config,
+            http_client,
+            global_config_persistence,
+            system_notifications,
+        )
+        .await;
+    drop(noop_system_notifications);
+    result
+}
+
+async fn run_telegram_adapter_with_client_and_global_config_persistence_and_system_notifications(
+    core: Arc<LucarneCore>,
+    config: TelegramConfig,
+    http_client: reqwest::Client,
+    global_config_persistence: Option<Arc<dyn lucarne_adapter::GlobalConfigPersistence>>,
+    system_notifications: SystemNotificationReceiver,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     lucarne::memory_profile_snapshot!("lucarne_telegram.adapter.run.start");
     info!(
         target: "lucarne_telegram::adapter",
@@ -140,7 +165,8 @@ pub async fn run_telegram_adapter_with_client_and_global_config_persistence(
     lucarne::memory_profile_snapshot!("lucarne_telegram.adapter.run.after_bot_new");
     info!(target: "lucarne_telegram::adapter", "telegram adapter started");
     lucarne::memory_profile_snapshot!("lucarne_telegram.adapter.run.before_bot_run");
-    bot.run().await;
+    bot.run_with_system_notifications(system_notifications)
+        .await;
     info!(target: "lucarne_telegram::adapter", "telegram adapter stopped");
     Ok(())
 }

--- a/crates/lucarne-telegram/src/bot.rs
+++ b/crates/lucarne-telegram/src/bot.rs
@@ -38,7 +38,10 @@ use lucarne::{
         TurnPermit, TurnScheduler,
     },
 };
-use lucarne_adapter::{GlobalConfigPersistence, GlobalConfigUpdate};
+use lucarne_adapter::{
+    GlobalConfigPersistence, GlobalConfigUpdate, SystemNotification, SystemNotificationBus,
+    SystemNotificationReceiver,
+};
 use lucarne_channel::{
     agent_message::{render_agent_message_markdown, AgentMessageFooter},
     ingest,
@@ -504,6 +507,19 @@ impl Bot {
 
     /// Consume channel events forever.
     pub async fn run(self: Arc<Self>) {
+        let noop_system_notifications = SystemNotificationBus::new(1);
+        let system_notifications = noop_system_notifications.subscribe();
+        Arc::clone(&self)
+            .run_with_system_notifications(system_notifications)
+            .await;
+        drop(noop_system_notifications);
+    }
+
+    /// Consume channel events and daemon system notifications forever.
+    pub async fn run_with_system_notifications(
+        self: Arc<Self>,
+        mut system_notifications: SystemNotificationReceiver,
+    ) {
         lucarne::memory_profile_snapshot!("lucarne_telegram.bot.run.start");
         info!(target: "lucarne_telegram::bot", channel = self.channel.name(), "bot run loop starting");
         let core_watcher = {
@@ -550,21 +566,64 @@ impl Bot {
         }
 
         let mut stream = self.channel.subscribe();
+        let mut system_notifications_open = true;
         lucarne::memory_profile_snapshot!("lucarne_telegram.bot.run.after_channel_subscribe");
-        while let Some(ev) = stream.next().await {
-            let bot = self.clone();
-            tokio::spawn(async move {
-                if let Err(e) = bot.handle(ev).await {
-                    warn!(
-                        target: "lucarne_telegram::bot",
-                        error = %e,
-                        "handler error"
-                    );
+        loop {
+            tokio::select! {
+                event = stream.next() => {
+                    let Some(ev) = event else {
+                        break;
+                    };
+                    let bot = self.clone();
+                    tokio::spawn(async move {
+                        if let Err(e) = bot.handle(ev).await {
+                            warn!(
+                                target: "lucarne_telegram::bot",
+                                error = %e,
+                                "handler error"
+                            );
+                        }
+                    });
                 }
-            });
+                notification = system_notifications.recv(), if system_notifications_open => {
+                    match notification {
+                        Ok(notification) => {
+                            if let Err(e) = self.handle_system_notification(notification).await {
+                                warn!(
+                                    target: "lucarne_telegram::bot",
+                                    error = %e,
+                                    "system notification handler error"
+                                );
+                            }
+                        }
+                        Err(tokio::sync::broadcast::error::RecvError::Lagged(skipped)) => {
+                            warn!(target: "lucarne_telegram::bot", skipped, "system notification watch lagged");
+                        }
+                        Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                            system_notifications_open = false;
+                            warn!(target: "lucarne_telegram::bot", "system notification watch closed");
+                        }
+                    }
+                }
+            }
         }
         core_watcher.abort();
         warn!(target: "lucarne_telegram::bot", "channel event stream ended — bot stopping");
+    }
+
+    async fn handle_system_notification(
+        &self,
+        notification: SystemNotification,
+    ) -> Result<(), String> {
+        match notification {
+            SystemNotification::UpdateAvailable(update) => {
+                let msg = OutgoingMessage::markdown(update.body_markdown);
+                send_with_fallback(&*self.channel, &self.entry, msg, "lucarned")
+                    .await
+                    .map(|_| ())
+                    .map_err(|err| err.to_string())
+            }
+        }
     }
 
     async fn handle(self: Arc<Self>, ev: ChannelEvent) -> Result<(), String> {
@@ -7130,6 +7189,41 @@ mod tests {
 
         assert!(channel.send_results.lock().unwrap().is_empty());
         assert!(channel.sent.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn system_update_notification_sends_markdown_to_entry_chat() {
+        let channel = Arc::new(RecordingChannel::default());
+        let bot = test_bot(Arc::clone(&channel));
+
+        bot.handle_system_notification(lucarne_adapter::SystemNotification::UpdateAvailable(
+            lucarne_adapter::SystemUpdateNotification {
+                current_version: "0.1.0".into(),
+                latest_version: "0.2.0".into(),
+                release_name: "Lucarne 0.2.0".into(),
+                release_url: "https://github.com/tuchg/Lucarne/releases/tag/v0.2.0".into(),
+                published_at: Some("2026-05-21T00:00:00Z".into()),
+                body_markdown: "## Lucarne update available\n\nInstall with `lucarned update`."
+                    .into(),
+                install_hint: "installer command".into(),
+            },
+        ))
+        .await
+        .expect("send system update notification");
+
+        let sent = channel.sent.lock().unwrap();
+        assert_eq!(sent.len(), 1);
+        assert_eq!(sent[0].format, lucarne_channel::TextFormat::Markdown);
+        assert!(sent[0].body.contains("Lucarne update available"));
+        assert!(sent[0].reply_to.is_none());
+        assert!(!sent[0].silent);
+        drop(sent);
+
+        assert_eq!(
+            channel.sent_targets.lock().unwrap().clone(),
+            vec![String::new()]
+        );
+        assert!(channel.created_workspaces.lock().unwrap().is_empty());
     }
 
     #[tokio::test]

--- a/crates/lucarne-wechat/src/adapter.rs
+++ b/crates/lucarne-wechat/src/adapter.rs
@@ -10,6 +10,7 @@ use futures::{stream::BoxStream, StreamExt};
 use lucarne::{default_lucarned_home_dir, LucarneCore};
 use lucarne_adapter::{
     AdapterConfig, AdapterContext, AdapterError, AdapterPlugin, AdapterResult, AdapterTask,
+    SystemNotificationBus, SystemNotificationReceiver,
 };
 use qrcode::{types::Color, EcLevel, QrCode};
 use tokio::sync::{mpsc, watch};
@@ -144,6 +145,7 @@ impl AdapterPlugin for WechatAdapterPlugin {
         let core = Arc::clone(&ctx.core);
         let shutdown = ctx.shutdown.clone();
         let global_config_persistence = ctx.global_config_persistence.clone();
+        let system_notifications = ctx.system_notifications.subscribe();
         lucarne::memory_profile_snapshot!("lucarne_wechat.adapter.spawn.before_transport_new");
         let transport = Arc::new(
             WechatIlinkTransport::new_with_client(
@@ -179,6 +181,7 @@ impl AdapterPlugin for WechatAdapterPlugin {
                 shutdown,
                 transport,
                 global_config_persistence,
+                system_notifications,
             )
             .await
             .map_err(|err| AdapterError::message(err.to_string()))
@@ -362,7 +365,19 @@ pub async fn run_wechat_adapter(
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let transport = Arc::new(WechatIlinkTransport::new(&config, core.sqlite_connection()).await);
     transport.login(config.force_login).await?;
-    run_wechat_adapter_with_transport(core, config, shutdown, transport, None).await
+    let noop_system_notifications = SystemNotificationBus::new(1);
+    let system_notifications = noop_system_notifications.subscribe();
+    let result = run_wechat_adapter_with_transport(
+        core,
+        config,
+        shutdown,
+        transport,
+        None,
+        system_notifications,
+    )
+    .await;
+    drop(noop_system_notifications);
+    result
 }
 
 async fn run_wechat_adapter_with_transport(
@@ -371,6 +386,7 @@ async fn run_wechat_adapter_with_transport(
     shutdown: watch::Receiver<bool>,
     transport: Arc<WechatIlinkTransport>,
     global_config_persistence: Option<Arc<dyn lucarne_adapter::GlobalConfigPersistence>>,
+    system_notifications: SystemNotificationReceiver,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let poll_transport = Arc::clone(&transport);
     let poll_task = tokio::spawn(async move { poll_transport.run().await });
@@ -397,7 +413,9 @@ async fn run_wechat_adapter_with_transport(
     if let Some(reminder_config) = config.context_expiry_reminder.clone() {
         service = service.with_context_expiry_reminder(reminder_config);
     }
-    let result = service.run_until_shutdown(shutdown).await;
+    let result = service
+        .run_until_shutdown_with_system_notifications(shutdown, system_notifications)
+        .await;
     service.transport().stop().await?;
 
     match poll_task.await {

--- a/crates/lucarne-wechat/src/service.rs
+++ b/crates/lucarne-wechat/src/service.rs
@@ -26,7 +26,10 @@ use lucarne::{
         KillAgentRequest, KillAgentTarget, LucarneCore, ResumeWorkspaceRequest, SubmitTurnRequest,
     },
 };
-use lucarne_adapter::{GlobalConfigPersistence, GlobalConfigUpdate};
+use lucarne_adapter::{
+    GlobalConfigPersistence, GlobalConfigUpdate, SystemNotification, SystemNotificationBus,
+    SystemNotificationReceiver,
+};
 use lucarne_channel::{
     agent_message::{compact_path, format_cost_duration},
     robust::retry_attachment_delivery,
@@ -343,12 +346,27 @@ where
 
     pub async fn run_until_shutdown(
         &self,
+        shutdown: tokio::sync::watch::Receiver<bool>,
+    ) -> Result<(), WechatError> {
+        let noop_system_notifications = SystemNotificationBus::new(1);
+        let system_notifications = noop_system_notifications.subscribe();
+        let result = self
+            .run_until_shutdown_with_system_notifications(shutdown, system_notifications)
+            .await;
+        drop(noop_system_notifications);
+        result
+    }
+
+    pub async fn run_until_shutdown_with_system_notifications(
+        &self,
         mut shutdown: tokio::sync::watch::Receiver<bool>,
+        mut system_notifications: SystemNotificationReceiver,
     ) -> Result<(), WechatError> {
         let mut core_events = self.core.watch_events();
         let mut incoming = self.transport.subscribe();
         let mut user_interactions = self.transport.subscribe_user_interactions();
         let mut pending_retry = tokio::time::interval(self.pending_reply_retry_interval);
+        let mut system_notifications_open = true;
         pending_retry.set_missed_tick_behavior(MissedTickBehavior::Skip);
         self.send_startup_help().await;
         loop {
@@ -365,6 +383,26 @@ where
                             warn!(target: "lucarne_wechat::service", skipped, "core event watch lagged");
                         }
                         Err(tokio::sync::broadcast::error::RecvError::Closed) => return Ok(()),
+                    }
+                }
+                notification = system_notifications.recv(), if system_notifications_open => {
+                    match notification {
+                        Ok(notification) => {
+                            if let Err(err) = self.deliver_system_notification(notification).await {
+                                warn!(
+                                    target: "lucarne_wechat::service",
+                                    error = %err,
+                                    "wechat system notification ignored after delivery error"
+                                );
+                            }
+                        }
+                        Err(tokio::sync::broadcast::error::RecvError::Lagged(skipped)) => {
+                            warn!(target: "lucarne_wechat::service", skipped, "system notification watch lagged");
+                        }
+                        Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                            system_notifications_open = false;
+                            warn!(target: "lucarne_wechat::service", "system notification watch closed");
+                        }
                     }
                 }
                 _ = pending_retry.tick() => {
@@ -398,6 +436,127 @@ where
                 }
             }
         }
+    }
+
+    async fn deliver_system_notification(
+        &self,
+        notification: SystemNotification,
+    ) -> Result<(), WechatError> {
+        match notification {
+            SystemNotification::UpdateAvailable(update) => {
+                self.deliver_update_notification(&update.body_markdown)
+                    .await
+            }
+        }
+    }
+
+    async fn deliver_update_notification(&self, body: &str) -> Result<(), WechatError> {
+        let users = self.notification_users();
+        if users.is_empty() {
+            warn!(
+                target: "lucarne_wechat::service",
+                "wechat update notification skipped because no notification users are configured or remembered"
+            );
+            return Ok(());
+        }
+
+        if let Some(remaining) = self.rate_limit_remaining() {
+            warn!(
+                target: "lucarne_wechat::service",
+                remaining_ms = remaining.as_millis() as u64,
+                "wechat update notification skipped by active rate limit"
+            );
+            return Ok(());
+        }
+
+        for user_id in users {
+            let context = match self.transport.context_for_user(&user_id).await {
+                Ok(Some(context)) => context,
+                Ok(None) => {
+                    warn!(
+                        target: "lucarne_wechat::service",
+                        user_id = %user_id,
+                        "wechat update notification skipped: no stored context for user"
+                    );
+                    continue;
+                }
+                Err(WechatError::RateLimited {
+                    retry_after,
+                    message,
+                }) => {
+                    self.record_rate_limit(retry_after, &message);
+                    warn!(
+                        target: "lucarne_wechat::service",
+                        user_id = %user_id,
+                        retry_after_secs = retry_after.as_secs(),
+                        error = %message,
+                        "wechat update notification context lookup rate limited"
+                    );
+                    return Ok(());
+                }
+                Err(WechatError::Transport(err)) => {
+                    warn!(
+                        target: "lucarne_wechat::service",
+                        user_id = %user_id,
+                        error = %err,
+                        "wechat update notification context lookup failed"
+                    );
+                    continue;
+                }
+                Err(err) => {
+                    warn!(
+                        target: "lucarne_wechat::service",
+                        user_id = %user_id,
+                        error = %err,
+                        "wechat update notification context lookup failed"
+                    );
+                    continue;
+                }
+            };
+
+            match self.transport.send(&context, body).await {
+                Ok(receipt) => {
+                    debug!(
+                        target: "lucarne_wechat::service",
+                        user_id = %user_id,
+                        message_ids = ?receipt.message_ids,
+                        bytes = body.len(),
+                        "wechat update notification sent"
+                    );
+                }
+                Err(WechatError::RateLimited {
+                    retry_after,
+                    message,
+                }) => {
+                    self.record_rate_limit(retry_after, &message);
+                    warn!(
+                        target: "lucarne_wechat::service",
+                        user_id = %user_id,
+                        retry_after_secs = retry_after.as_secs(),
+                        error = %message,
+                        "wechat update notification rate limited"
+                    );
+                    return Ok(());
+                }
+                Err(WechatError::Transport(err)) => {
+                    warn!(
+                        target: "lucarne_wechat::service",
+                        user_id = %user_id,
+                        error = %err,
+                        "wechat update notification send failed"
+                    );
+                }
+                Err(err) => {
+                    warn!(
+                        target: "lucarne_wechat::service",
+                        user_id = %user_id,
+                        error = %err,
+                        "wechat update notification send failed"
+                    );
+                }
+            }
+        }
+        Ok(())
     }
 
     pub async fn handle_core_event(&self, event: CoreEvent) -> Result<(), WechatError> {
@@ -3084,6 +3243,80 @@ mod tests {
             "{}",
             replies[0].text
         );
+    }
+
+    #[tokio::test]
+    async fn system_update_notifications_send_to_configured_and_known_users_without_binding() {
+        let provider = Arc::new(FakeProvider::default());
+        let core = test_core(Arc::clone(&provider));
+        let transport = Arc::new(FakeTransport::default());
+        let service = Arc::new(WechatNotificationService::new(
+            Arc::clone(&core),
+            Arc::clone(&transport),
+            WechatServiceOptions {
+                initial_user_ids: vec!["user-1".into()],
+                ..WechatServiceOptions::default()
+            },
+        ));
+        service.remember_user("user-2");
+
+        let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+        let system_notifications = lucarne_adapter::SystemNotificationBus::new(8);
+        let receiver = system_notifications.subscribe();
+        let run = tokio::spawn({
+            let service = Arc::clone(&service);
+            async move {
+                service
+                    .run_until_shutdown_with_system_notifications(shutdown_rx, receiver)
+                    .await
+            }
+        });
+
+        assert_eq!(
+            system_notifications.send(lucarne_adapter::SystemNotification::UpdateAvailable(
+                lucarne_adapter::SystemUpdateNotification {
+                    current_version: "0.1.0".into(),
+                    latest_version: "0.2.0".into(),
+                    release_name: "Lucarne 0.2.0".into(),
+                    release_url: "https://github.com/tuchg/Lucarne/releases/tag/v0.2.0".into(),
+                    published_at: Some("2026-05-21T00:00:00Z".into()),
+                    body_markdown: "## Lucarne update available\n\nInstall with `lucarned update`."
+                        .into(),
+                    install_hint: "installer command".into(),
+                },
+            )),
+            1
+        );
+
+        for _ in 0..20 {
+            if transport.sends().len() >= 2 {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+
+        let sends = transport.sends();
+        assert_eq!(sends.len(), 2);
+        let sent_users = sends
+            .iter()
+            .map(|send| send.user_id.as_str())
+            .collect::<BTreeSet<_>>();
+        assert_eq!(sent_users, BTreeSet::from(["user-1", "user-2"]));
+        for send in &sends {
+            assert!(send.text.contains("Lucarne update available"));
+            assert!(
+                core.message_session_binding("wechat", &send.user_id, &send.message_id)
+                    .is_none(),
+                "system updates must not bind provider sessions"
+            );
+        }
+
+        shutdown_tx.send(true).expect("request shutdown");
+        tokio::time::timeout(Duration::from_secs(1), run)
+            .await
+            .expect("service exits after shutdown")
+            .expect("service task")
+            .expect("service result");
     }
 
     #[tokio::test]

--- a/crates/lucarned-ctl/Cargo.toml
+++ b/crates/lucarned-ctl/Cargo.toml
@@ -8,4 +8,19 @@ repository.workspace = true
 homepage.workspace = true
 description = "Control helpers for lucarned installation diagnostics and autostart."
 
+[features]
+default = []
+updates = [
+    "dep:reqwest",
+    "dep:semver",
+    "dep:serde",
+    "dep:serde_json",
+    "dep:tokio",
+]
+
 [dependencies]
+reqwest = { workspace = true, optional = true }
+semver = { version = "1", optional = true }
+serde = { workspace = true, optional = true }
+serde_json = { workspace = true, optional = true }
+tokio = { workspace = true, optional = true }

--- a/crates/lucarned-ctl/src/args.rs
+++ b/crates/lucarned-ctl/src/args.rs
@@ -8,6 +8,7 @@ pub enum Command {
     Init,
     Paths,
     Doctor,
+    Update,
     Autostart(AutostartCommand),
 }
 
@@ -53,6 +54,7 @@ fn parse_first(first: OsString, rest: Vec<OsString>) -> Result<Command, ParseErr
         "init" => require_no_args(Command::Init, rest),
         "paths" => require_no_args(Command::Paths, rest),
         "doctor" => require_no_args(Command::Doctor, rest),
+        "update" => require_no_args(Command::Update, rest),
         "autostart" => parse_autostart(rest),
         other => Err(ParseError::new(format!("unknown command: {other}"))),
     }
@@ -137,6 +139,7 @@ Usage:\n\
   lucarned                         Run daemon\n\
   lucarned init                    Configure lucarned interactively\n\
   lucarned doctor                  Diagnose install and runtime state\n\
+  lucarned update                  Check latest Lucarne release status\n\
   lucarned paths                   Print resolved paths\n\
   lucarned autostart install [--start] [--bin PATH]\n\
   lucarned autostart uninstall [--stop]\n\
@@ -169,6 +172,10 @@ mod tests {
             Command::Doctor
         );
         assert_eq!(
+            parse_words(&["lucarned", "update"]).unwrap(),
+            Command::Update
+        );
+        assert_eq!(
             parse_words(&["lucarned", "--version"]).unwrap(),
             Command::Version
         );
@@ -199,6 +206,11 @@ mod tests {
             parse_words(&["lucarned", "autostart", "uninstall", "--stop"]).unwrap(),
             Command::Autostart(AutostartCommand::Uninstall { stop: true })
         );
+    }
+
+    #[test]
+    fn usage_lists_update_command() {
+        assert!(usage().contains("lucarned update"));
     }
 
     #[test]

--- a/crates/lucarned-ctl/src/doctor.rs
+++ b/crates/lucarned-ctl/src/doctor.rs
@@ -21,18 +21,45 @@ pub struct Check {
 
 pub fn run_doctor() -> Result<(), String> {
     let checks = collect_checks()?;
-    for check in &checks {
+    print_checks(&checks);
+    if checks.iter().any(|check| check.level == CheckLevel::Fail) {
+        Err("doctor found critical failures".to_string())
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(feature = "updates")]
+pub async fn run_doctor_async(
+    client: &reqwest::Client,
+    update_config: crate::updates::UpdateConfig,
+    update_config_warning: Option<String>,
+) -> Result<(), String> {
+    let mut checks = collect_checks()?;
+    if let Some(message) = update_config_warning {
+        checks.push(Check {
+            level: CheckLevel::Warn,
+            name: "update-config",
+            message,
+        });
+    }
+    checks.push(update_check(client, update_config).await);
+    print_checks(&checks);
+    if checks.iter().any(|check| check.level == CheckLevel::Fail) {
+        Err("doctor found critical failures".to_string())
+    } else {
+        Ok(())
+    }
+}
+
+fn print_checks(checks: &[Check]) {
+    for check in checks {
         let prefix = match check.level {
             CheckLevel::Ok => "ok",
             CheckLevel::Warn => "warn",
             CheckLevel::Fail => "fail",
         };
         println!("{prefix}: {}: {}", check.name, check.message);
-    }
-    if checks.iter().any(|check| check.level == CheckLevel::Fail) {
-        Err("doctor found critical failures".to_string())
-    } else {
-        Ok(())
     }
 }
 
@@ -62,6 +89,77 @@ fn collect_checks() -> Result<Vec<Check>, String> {
         checks.push(optional_cli(agent));
     }
     Ok(checks)
+}
+
+#[cfg(feature = "updates")]
+async fn update_check(
+    client: &reqwest::Client,
+    update_config: crate::updates::UpdateConfig,
+) -> Check {
+    if !update_config.enabled {
+        return Check {
+            level: CheckLevel::Ok,
+            name: "update",
+            message: "checks disabled by config".to_string(),
+        };
+    }
+
+    match tokio::time::timeout(
+        std::time::Duration::from_secs(10),
+        crate::updates::check_now(client, &update_config, env!("CARGO_PKG_VERSION")),
+    )
+    .await
+    {
+        Ok(Ok(status)) => {
+            let (level, message) = update_check_message(&status);
+            Check {
+                level,
+                name: "update",
+                message,
+            }
+        }
+        Ok(Err(err)) => Check {
+            level: CheckLevel::Warn,
+            name: "update",
+            message: format!("check failed: {err}"),
+        },
+        Err(_) => Check {
+            level: CheckLevel::Warn,
+            name: "update",
+            message: "check failed: timed out after 10s".to_string(),
+        },
+    }
+}
+
+#[cfg(feature = "updates")]
+fn update_check_message(status: &crate::updates::UpdateStatus) -> (CheckLevel, String) {
+    if !status.automatic_checks_enabled {
+        return (CheckLevel::Ok, "checks disabled by config".to_string());
+    }
+
+    if status.is_newer {
+        let latest = status.latest_version.as_deref().unwrap_or("unknown");
+        let url = status
+            .release_url
+            .as_deref()
+            .unwrap_or("release URL unavailable");
+        return (CheckLevel::Warn, format!("{latest} available: {url}"));
+    }
+
+    if let Some(latest) = &status.latest_version {
+        return (
+            CheckLevel::Ok,
+            format!(
+                "current version {} (latest {latest})",
+                status.current_version
+            ),
+        );
+    }
+
+    (
+        CheckLevel::Warn,
+        "no stable GitHub release found".to_string(),
+    )
 }
 
 fn check_lucarned_help(path: &Path) -> Check {
@@ -409,6 +507,42 @@ mod tests {
             parse_proc_self_limit_soft(raw, "Max open files"),
             Some(1_024)
         );
+    }
+
+    #[cfg(feature = "updates")]
+    #[tokio::test]
+    async fn disabled_update_check_is_ok() {
+        let client = reqwest::Client::new();
+        let check = update_check(
+            &client,
+            crate::updates::UpdateConfig {
+                enabled: false,
+                ..crate::updates::UpdateConfig::default()
+            },
+        )
+        .await;
+
+        assert_eq!(check.level, CheckLevel::Ok);
+        assert_eq!(check.name, "update");
+        assert_eq!(check.message, "checks disabled by config");
+    }
+
+    #[cfg(feature = "updates")]
+    #[tokio::test]
+    async fn failed_update_check_is_warning() {
+        let client = reqwest::Client::new();
+        let check = update_check(
+            &client,
+            crate::updates::UpdateConfig {
+                repository: "not-a-repository".to_string(),
+                ..crate::updates::UpdateConfig::default()
+            },
+        )
+        .await;
+
+        assert_eq!(check.level, CheckLevel::Warn);
+        assert_eq!(check.name, "update");
+        assert!(check.message.contains("check failed:"));
     }
 
     #[cfg(target_os = "linux")]

--- a/crates/lucarned-ctl/src/lib.rs
+++ b/crates/lucarned-ctl/src/lib.rs
@@ -3,6 +3,8 @@ pub mod autostart;
 pub mod doctor;
 pub mod paths;
 pub mod process;
+#[cfg(feature = "updates")]
+pub mod updates;
 
 pub use args::{parse, usage, AutostartCommand, Command, ParseError};
 
@@ -24,7 +26,35 @@ pub fn run(command: Command) -> Result<(), String> {
             Ok(())
         }
         Command::Doctor => doctor::run_doctor(),
+        Command::Update => update_requires_async_or_feature(),
         Command::Autostart(command) => run_autostart(command),
+    }
+}
+
+#[cfg(feature = "updates")]
+pub async fn run_async(
+    command: Command,
+    client: &reqwest::Client,
+    update_config: updates::UpdateConfig,
+    update_config_warning: Option<String>,
+) -> Result<(), String> {
+    match command {
+        Command::Doctor => {
+            doctor::run_doctor_async(client, update_config, update_config_warning).await
+        }
+        Command::Update => updates::run_update_command(client, update_config).await,
+        other => run(other),
+    }
+}
+
+fn update_requires_async_or_feature() -> Result<(), String> {
+    #[cfg(feature = "updates")]
+    {
+        Err("update command requires async lucarned-ctl runner".to_string())
+    }
+    #[cfg(not(feature = "updates"))]
+    {
+        Err("update command requires lucarned-ctl updates feature".to_string())
     }
 }
 

--- a/crates/lucarned-ctl/src/updates/github.rs
+++ b/crates/lucarned-ctl/src/updates/github.rs
@@ -1,0 +1,210 @@
+use reqwest::header::{ACCEPT, USER_AGENT};
+use serde::Deserialize;
+
+use super::UpdateError;
+
+const GITHUB_API_ACCEPT: &str = "application/vnd.github+json";
+const MAX_RESPONSE_BYTES: usize = 128 * 1024;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GithubRelease {
+    pub tag_name: String,
+    pub name: String,
+    pub html_url: String,
+    pub body: String,
+    pub published_at: Option<String>,
+    pub draft: bool,
+    pub prerelease: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct GithubReleaseJson {
+    tag_name: String,
+    #[serde(default)]
+    name: String,
+    html_url: String,
+    #[serde(default)]
+    body: String,
+    published_at: Option<String>,
+    #[serde(default)]
+    draft: bool,
+    #[serde(default)]
+    prerelease: bool,
+}
+
+pub fn parse_release_json(raw: &str) -> Result<GithubRelease, serde_json::Error> {
+    let json: GithubReleaseJson = serde_json::from_str(raw)?;
+    Ok(GithubRelease {
+        tag_name: json.tag_name,
+        name: json.name,
+        html_url: json.html_url,
+        body: json.body,
+        published_at: json.published_at,
+        draft: json.draft,
+        prerelease: json.prerelease,
+    })
+}
+
+pub async fn fetch_latest_release(
+    client: &reqwest::Client,
+    repository: &str,
+    user_agent: &str,
+) -> Result<Option<GithubRelease>, UpdateError> {
+    if !is_valid_repository(repository) {
+        return Err(UpdateError::InvalidRepository(repository.to_string()));
+    }
+
+    let url = format!("https://api.github.com/repos/{repository}/releases/latest");
+    let mut response = client
+        .get(url)
+        .header(USER_AGENT, user_agent)
+        .header(ACCEPT, GITHUB_API_ACCEPT)
+        .send()
+        .await?;
+
+    let status = response.status();
+    if !status.is_success() {
+        return Err(UpdateError::HttpStatus(status));
+    }
+
+    if let Some(length) = response.content_length() {
+        if length > MAX_RESPONSE_BYTES as u64 {
+            return Err(UpdateError::ResponseTooLarge {
+                limit: MAX_RESPONSE_BYTES,
+                actual: length.min(usize::MAX as u64) as usize,
+            });
+        }
+    }
+
+    let mut body = Vec::new();
+    while let Some(chunk) = response.chunk().await? {
+        let actual = body.len().saturating_add(chunk.len());
+        if actual > MAX_RESPONSE_BYTES {
+            return Err(UpdateError::ResponseTooLarge {
+                limit: MAX_RESPONSE_BYTES,
+                actual,
+            });
+        }
+        body.extend_from_slice(&chunk);
+    }
+
+    let body = String::from_utf8_lossy(&body);
+    let release = parse_release_json(&body)?;
+    if release.draft || release.prerelease {
+        return Ok(None);
+    }
+    Ok(Some(release))
+}
+
+fn is_valid_repository(repository: &str) -> bool {
+    let mut parts = repository.split('/');
+    let (Some(owner), Some(repo), None) = (parts.next(), parts.next(), parts.next()) else {
+        return false;
+    };
+    is_valid_repository_part(owner) && is_valid_repository_part(repo)
+}
+
+fn is_valid_repository_part(part: &str) -> bool {
+    !part.is_empty()
+        && part.bytes().all(
+            |byte| matches!(byte, b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'.' | b'_' | b'-'),
+        )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_normal_release_json() {
+        let release = parse_release_json(
+            r#"{
+                "tag_name": "v0.2.0",
+                "name": "Lucarne 0.2.0",
+                "html_url": "https://github.com/tuchg/Lucarne/releases/tag/v0.2.0",
+                "body": "Changes",
+                "published_at": "2026-05-21T00:00:00Z",
+                "draft": false,
+                "prerelease": false
+            }"#,
+        )
+        .unwrap();
+
+        assert_eq!(release.tag_name, "v0.2.0");
+        assert_eq!(release.name, "Lucarne 0.2.0");
+        assert_eq!(
+            release.html_url,
+            "https://github.com/tuchg/Lucarne/releases/tag/v0.2.0"
+        );
+        assert_eq!(release.body, "Changes");
+        assert_eq!(
+            release.published_at.as_deref(),
+            Some("2026-05-21T00:00:00Z")
+        );
+        assert!(!release.draft);
+        assert!(!release.prerelease);
+    }
+
+    #[test]
+    fn parses_prerelease_and_draft_flags() {
+        let prerelease = parse_release_json(
+            r#"{
+                "tag_name": "v0.3.0-beta.1",
+                "name": "Beta",
+                "html_url": "https://example.invalid/beta",
+                "prerelease": true
+            }"#,
+        )
+        .unwrap();
+        assert!(prerelease.prerelease);
+        assert!(!prerelease.draft);
+
+        let draft = parse_release_json(
+            r#"{
+                "tag_name": "v0.3.0",
+                "name": "Draft",
+                "html_url": "https://example.invalid/draft",
+                "draft": true
+            }"#,
+        )
+        .unwrap();
+        assert!(draft.draft);
+        assert!(!draft.prerelease);
+    }
+
+    #[test]
+    fn missing_optional_fields_default() {
+        let release = parse_release_json(
+            r#"{
+                "tag_name": "v0.2.0",
+                "html_url": "https://example.invalid/release"
+            }"#,
+        )
+        .unwrap();
+
+        assert_eq!(release.name, "");
+        assert_eq!(release.body, "");
+        assert_eq!(release.published_at, None);
+        assert!(!release.draft);
+        assert!(!release.prerelease);
+    }
+
+    #[tokio::test]
+    async fn invalid_repository_is_rejected_before_request() {
+        let client = reqwest::Client::new();
+        for repository in [
+            "tuchg",
+            "tuchg/",
+            "/Lucarne",
+            "tuchg/Lucarne/extra",
+            "bad repo/Lucarne",
+        ] {
+            let err = fetch_latest_release(&client, repository, "lucarned-test")
+                .await
+                .unwrap_err();
+            assert!(
+                matches!(err, UpdateError::InvalidRepository(invalid) if invalid == repository)
+            );
+        }
+    }
+}

--- a/crates/lucarned-ctl/src/updates/mod.rs
+++ b/crates/lucarned-ctl/src/updates/mod.rs
@@ -1,0 +1,499 @@
+mod github;
+mod render;
+mod state;
+mod version;
+
+use std::fmt;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+pub use github::{fetch_latest_release, parse_release_json, GithubRelease};
+pub use render::{
+    render_doctor_message, render_update_cli, render_update_notification, truncate_release_body,
+    INSTALL_HINT,
+};
+pub use state::{should_notify, UpdateState, UpdateStateStore};
+pub use version::{is_newer_version, normalize_tag, parse_version};
+
+#[derive(Debug)]
+pub enum UpdateError {
+    InvalidRepository(String),
+    Http(reqwest::Error),
+    HttpStatus(reqwest::StatusCode),
+    ResponseTooLarge { limit: usize, actual: usize },
+    Json(serde_json::Error),
+    Version(semver::Error),
+}
+
+impl fmt::Display for UpdateError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidRepository(repository) => {
+                write!(f, "invalid GitHub repository: {repository}")
+            }
+            Self::Http(err) => write!(f, "GitHub request failed: {err}"),
+            Self::HttpStatus(status) => write!(f, "GitHub request returned HTTP {status}"),
+            Self::ResponseTooLarge { limit, actual } => {
+                write!(f, "GitHub response exceeded {limit} bytes: {actual}")
+            }
+            Self::Json(err) => write!(f, "GitHub response JSON was invalid: {err}"),
+            Self::Version(err) => write!(f, "release version was invalid: {err}"),
+        }
+    }
+}
+
+impl std::error::Error for UpdateError {}
+
+impl From<reqwest::Error> for UpdateError {
+    fn from(err: reqwest::Error) -> Self {
+        Self::Http(err)
+    }
+}
+
+impl From<serde_json::Error> for UpdateError {
+    fn from(err: serde_json::Error) -> Self {
+        Self::Json(err)
+    }
+}
+
+impl From<semver::Error> for UpdateError {
+    fn from(err: semver::Error) -> Self {
+        Self::Version(err)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct UpdateConfig {
+    pub enabled: bool,
+    pub notify: bool,
+    pub check_interval: Duration,
+    pub remind_interval: Duration,
+    pub repository: String,
+    pub startup_delay: Duration,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UpdateStatus {
+    pub current_version: String,
+    pub latest_version: Option<String>,
+    pub release_name: Option<String>,
+    pub release_url: Option<String>,
+    pub published_at: Option<String>,
+    pub release_body: Option<String>,
+    pub is_newer: bool,
+    pub automatic_checks_enabled: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UpdateNotice {
+    pub current_version: String,
+    pub latest_version: String,
+    pub release_name: String,
+    pub release_url: String,
+    pub published_at: Option<String>,
+    pub body_markdown: String,
+    pub install_hint: String,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct UpdateRuntimeTick {
+    pub notice: Option<UpdateNotice>,
+    pub warnings: Vec<String>,
+}
+
+impl Default for UpdateConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            notify: true,
+            check_interval: Duration::from_secs(24 * 60 * 60),
+            remind_interval: Duration::from_secs(24 * 60 * 60),
+            repository: "tuchg/Lucarne".to_string(),
+            startup_delay: Duration::from_secs(60),
+        }
+    }
+}
+
+pub async fn check_now(
+    client: &reqwest::Client,
+    config: &UpdateConfig,
+    current_version: &str,
+) -> Result<UpdateStatus, UpdateError> {
+    if !config.enabled {
+        return Ok(UpdateStatus {
+            current_version: current_version.to_string(),
+            latest_version: None,
+            release_name: None,
+            release_url: None,
+            published_at: None,
+            release_body: None,
+            is_newer: false,
+            automatic_checks_enabled: false,
+        });
+    }
+
+    let user_agent = format!("lucarned/{current_version}");
+    let Some(release) = fetch_latest_release(client, &config.repository, &user_agent).await? else {
+        return Ok(UpdateStatus {
+            current_version: current_version.to_string(),
+            latest_version: None,
+            release_name: None,
+            release_url: None,
+            published_at: None,
+            release_body: None,
+            is_newer: false,
+            automatic_checks_enabled: true,
+        });
+    };
+
+    let latest_version = normalize_tag(&release.tag_name).to_string();
+    let is_newer = is_newer_version(current_version, &release.tag_name)?;
+    let release_name = if release.name.trim().is_empty() {
+        latest_version.clone()
+    } else {
+        release.name
+    };
+
+    Ok(UpdateStatus {
+        current_version: current_version.to_string(),
+        latest_version: Some(latest_version),
+        release_name: Some(release_name),
+        release_url: Some(release.html_url),
+        published_at: release.published_at,
+        release_body: Some(release.body),
+        is_newer,
+        automatic_checks_enabled: true,
+    })
+}
+
+pub async fn run_update_command(
+    client: &reqwest::Client,
+    update_config: UpdateConfig,
+) -> Result<(), String> {
+    let automatic_checks_enabled = update_config.enabled;
+    let mut manual_config = update_config;
+    manual_config.enabled = true;
+    let mut status = check_now(client, &manual_config, env!("CARGO_PKG_VERSION"))
+        .await
+        .map_err(|err| err.to_string())?;
+    status.automatic_checks_enabled = automatic_checks_enabled;
+    print!("{}", render_update_cli(&status));
+    Ok(())
+}
+
+pub struct UpdateRuntime {
+    config: UpdateConfig,
+    state_store: UpdateStateStore,
+    next_due: tokio::time::Instant,
+}
+
+impl UpdateRuntime {
+    pub fn new(config: UpdateConfig, state_store: UpdateStateStore) -> Self {
+        let next_due = tokio::time::Instant::now() + config.startup_delay;
+        Self {
+            config,
+            state_store,
+            next_due,
+        }
+    }
+
+    pub fn enabled(&self) -> bool {
+        self.config.enabled
+    }
+
+    pub async fn next_notice(
+        &mut self,
+        client: &reqwest::Client,
+        current_version: &str,
+    ) -> Option<UpdateNotice> {
+        self.next_tick(client, current_version).await.notice
+    }
+
+    pub async fn next_tick(
+        &mut self,
+        client: &reqwest::Client,
+        current_version: &str,
+    ) -> UpdateRuntimeTick {
+        if !self.enabled() {
+            return UpdateRuntimeTick::default();
+        }
+
+        tokio::time::sleep_until(self.next_due).await;
+        self.next_due = tokio::time::Instant::now() + self.config.check_interval;
+
+        let status = match tokio::time::timeout(
+            Duration::from_secs(10),
+            check_now(client, &self.config, current_version),
+        )
+        .await
+        {
+            Ok(Ok(status)) => status,
+            Ok(Err(err)) => {
+                return UpdateRuntimeTick {
+                    notice: None,
+                    warnings: vec![format!("update check failed: {err}")],
+                };
+            }
+            Err(_) => {
+                return UpdateRuntimeTick {
+                    notice: None,
+                    warnings: vec!["update check failed: timed out after 10s".to_string()],
+                };
+            }
+        };
+
+        update_state_and_build_notice(&self.config, &self.state_store, &status, now_unix_secs())
+    }
+
+    pub fn record_notice_delivered(&self, notice: &UpdateNotice) {
+        let _ = record_notice_delivered(&self.state_store, &notice.latest_version, now_unix_secs());
+    }
+}
+
+fn update_state_and_build_notice(
+    config: &UpdateConfig,
+    state_store: &UpdateStateStore,
+    status: &UpdateStatus,
+    now_unix_secs: u64,
+) -> UpdateRuntimeTick {
+    let mut warnings = Vec::new();
+    let mut state = match state_store.load() {
+        Ok(state) => state,
+        Err(err) => {
+            warnings.push(format!(
+                "update state {} could not be read; recreating: {err}",
+                state_store.path().display()
+            ));
+            UpdateState::default()
+        }
+    };
+
+    state.last_checked_at_unix_secs = Some(now_unix_secs);
+    state.last_latest_version = status.latest_version.clone();
+    state.last_latest_url = status.release_url.clone();
+
+    let mut notice = None;
+    if status.is_newer && config.notify {
+        if let (Some(latest_version), Some(release_url)) =
+            (status.latest_version.clone(), status.release_url.clone())
+        {
+            if should_notify(
+                &state,
+                &latest_version,
+                now_unix_secs,
+                config.remind_interval.as_secs(),
+            ) {
+                let release_name = status
+                    .release_name
+                    .clone()
+                    .filter(|name| !name.trim().is_empty())
+                    .unwrap_or_else(|| latest_version.clone());
+                notice = Some(UpdateNotice {
+                    current_version: status.current_version.clone(),
+                    latest_version,
+                    release_name,
+                    release_url,
+                    published_at: status.published_at.clone(),
+                    body_markdown: render_update_notification(status),
+                    install_hint: INSTALL_HINT.to_string(),
+                });
+            }
+        }
+    }
+
+    if let Err(err) = state_store.save(&state) {
+        warnings.push(format!(
+            "update state {} could not be saved; reminder throttling may not persist: {err}",
+            state_store.path().display()
+        ));
+    }
+
+    UpdateRuntimeTick { notice, warnings }
+}
+
+fn record_notice_delivered(
+    state_store: &UpdateStateStore,
+    latest_version: &str,
+    now_unix_secs: u64,
+) -> Result<(), std::io::Error> {
+    let mut state = state_store.load()?;
+    state.last_notified_version = Some(latest_version.to_string());
+    state.last_notified_at_unix_secs = Some(now_unix_secs);
+    state_store.save(&state)
+}
+
+fn now_unix_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs())
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temp_state_path(name: &str) -> PathBuf {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!(
+            "lucarned-ctl-update-runtime-{name}-{}-{unique}.json",
+            std::process::id()
+        ))
+    }
+
+    fn newer_status() -> UpdateStatus {
+        UpdateStatus {
+            current_version: "0.1.0".to_string(),
+            latest_version: Some("0.2.0".to_string()),
+            release_name: Some("Lucarne 0.2.0".to_string()),
+            release_url: Some("https://example.invalid/release".to_string()),
+            published_at: Some("2026-05-21T00:00:00Z".to_string()),
+            release_body: Some("Changes".to_string()),
+            is_newer: true,
+            automatic_checks_enabled: true,
+        }
+    }
+
+    #[test]
+    fn config_default_matches_design() {
+        let config = UpdateConfig::default();
+        assert!(config.enabled);
+        assert!(config.notify);
+        assert_eq!(config.check_interval, Duration::from_secs(24 * 60 * 60));
+        assert_eq!(config.remind_interval, Duration::from_secs(24 * 60 * 60));
+        assert_eq!(config.repository, "tuchg/Lucarne");
+        assert_eq!(config.startup_delay, Duration::from_secs(60));
+    }
+
+    #[tokio::test]
+    async fn disabled_check_does_not_report_latest() {
+        let client = reqwest::Client::new();
+        let config = UpdateConfig {
+            enabled: false,
+            ..UpdateConfig::default()
+        };
+        let status = check_now(&client, &config, "0.1.0").await.unwrap();
+        assert_eq!(status.current_version, "0.1.0");
+        assert_eq!(status.latest_version, None);
+        assert!(!status.is_newer);
+        assert!(!status.automatic_checks_enabled);
+    }
+
+    #[tokio::test]
+    async fn disabled_runtime_returns_no_notice() {
+        let client = reqwest::Client::new();
+        let config = UpdateConfig {
+            enabled: false,
+            startup_delay: Duration::from_secs(0),
+            ..UpdateConfig::default()
+        };
+        let store = UpdateStateStore::new(PathBuf::from("/tmp/lucarned-ctl-disabled-runtime.json"));
+        let mut runtime = UpdateRuntime::new(config, store);
+        assert!(!runtime.enabled());
+        assert_eq!(runtime.next_notice(&client, "0.1.0").await, None);
+    }
+
+    #[test]
+    fn newer_status_builds_notice_and_updates_state() {
+        let path = temp_state_path("notice");
+        let store = UpdateStateStore::new(path.clone());
+        let config = UpdateConfig {
+            remind_interval: Duration::from_secs(100),
+            ..UpdateConfig::default()
+        };
+
+        let tick = update_state_and_build_notice(&config, &store, &newer_status(), 200);
+        assert!(tick.warnings.is_empty());
+        let notice = tick.notice.unwrap();
+
+        assert_eq!(notice.latest_version, "0.2.0");
+        assert_eq!(notice.release_name, "Lucarne 0.2.0");
+        assert!(notice.body_markdown.contains("Lucarne update available"));
+        assert!(notice.body_markdown.contains("Current: 0.1.0"));
+        assert!(notice.body_markdown.contains("Latest: 0.2.0"));
+        assert!(notice.body_markdown.contains("Changes"));
+        assert!(notice.body_markdown.contains("curl -fsSL"));
+        assert_eq!(notice.install_hint, INSTALL_HINT);
+        assert_eq!(
+            store.load().unwrap(),
+            UpdateState {
+                last_checked_at_unix_secs: Some(200),
+                last_latest_version: Some("0.2.0".to_string()),
+                last_latest_url: Some("https://example.invalid/release".to_string()),
+                last_notified_version: None,
+                last_notified_at_unix_secs: None,
+            }
+        );
+        record_notice_delivered(&store, &notice.latest_version, 201).unwrap();
+        let state = store.load().unwrap();
+        assert_eq!(state.last_notified_version.as_deref(), Some("0.2.0"));
+        assert_eq!(state.last_notified_at_unix_secs, Some(201));
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn notify_false_updates_state_without_notice() {
+        let path = temp_state_path("notify-false");
+        let store = UpdateStateStore::new(path.clone());
+        let config = UpdateConfig {
+            notify: false,
+            ..UpdateConfig::default()
+        };
+
+        let tick = update_state_and_build_notice(&config, &store, &newer_status(), 200);
+        assert!(tick.warnings.is_empty());
+        assert_eq!(tick.notice, None);
+        let state = store.load().unwrap();
+        assert_eq!(state.last_checked_at_unix_secs, Some(200));
+        assert_eq!(state.last_latest_version.as_deref(), Some("0.2.0"));
+        assert_eq!(state.last_notified_version, None);
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn throttled_version_updates_check_without_notice() {
+        let path = temp_state_path("throttled");
+        let store = UpdateStateStore::new(path.clone());
+        store
+            .save(&UpdateState {
+                last_notified_version: Some("0.2.0".to_string()),
+                last_notified_at_unix_secs: Some(150),
+                ..UpdateState::default()
+            })
+            .unwrap();
+        let config = UpdateConfig {
+            remind_interval: Duration::from_secs(100),
+            ..UpdateConfig::default()
+        };
+
+        let tick = update_state_and_build_notice(&config, &store, &newer_status(), 200);
+        assert!(tick.warnings.is_empty());
+        assert_eq!(tick.notice, None);
+        let state = store.load().unwrap();
+        assert_eq!(state.last_checked_at_unix_secs, Some(200));
+        assert_eq!(state.last_latest_version.as_deref(), Some("0.2.0"));
+        assert_eq!(state.last_notified_at_unix_secs, Some(150));
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn malformed_state_warns_and_still_builds_notice() {
+        let path = temp_state_path("malformed-runtime");
+        std::fs::write(&path, "not json").unwrap();
+        let store = UpdateStateStore::new(path.clone());
+
+        let tick =
+            update_state_and_build_notice(&UpdateConfig::default(), &store, &newer_status(), 200);
+
+        assert!(tick.notice.is_some());
+        assert_eq!(tick.warnings.len(), 1);
+        assert!(tick.warnings[0].contains("could not be read"));
+        let state = store.load().unwrap();
+        assert_eq!(state.last_latest_version.as_deref(), Some("0.2.0"));
+        let _ = std::fs::remove_file(path);
+    }
+}

--- a/crates/lucarned-ctl/src/updates/render.rs
+++ b/crates/lucarned-ctl/src/updates/render.rs
@@ -1,0 +1,190 @@
+use super::UpdateStatus;
+
+const CLI_CHANGE_LIMIT: usize = 4_000;
+const NOTIFICATION_CHANGE_LIMIT: usize = 1_800;
+
+pub const INSTALL_HINT: &str = "macOS/Linux:\n  curl -fsSL https://github.com/tuchg/Lucarne/releases/latest/download/lucarned-installer.sh | sh\n\nWindows PowerShell:\n  irm https://github.com/tuchg/Lucarne/releases/latest/download/lucarned-installer.ps1 | iex\n\nIf installed through a package manager, upgrade with that package manager.";
+
+pub fn truncate_release_body(body: &str, max_chars: usize) -> String {
+    if body.chars().count() <= max_chars {
+        return body.to_string();
+    }
+
+    let mut truncated: String = body.chars().take(max_chars).collect();
+    truncated.push_str("...(truncated)");
+    truncated
+}
+
+pub fn render_update_cli(status: &UpdateStatus) -> String {
+    let mut output = String::new();
+    output.push_str("Lucarne update status\n");
+    output.push_str(&format!("Current version: {}\n", status.current_version));
+
+    if !status.automatic_checks_enabled {
+        output.push_str("Automatic update checks: disabled by config\n");
+    }
+
+    let Some(latest_version) = &status.latest_version else {
+        output.push_str("Latest version: unavailable\nNo stable GitHub release found.\n");
+        return output;
+    };
+
+    output.push_str(&format!("Latest version: {latest_version}\n"));
+    if status.is_newer {
+        output.push_str("Status: update available\n");
+    } else {
+        output.push_str("Status: lucarned is up to date (current)\n");
+    }
+
+    if let Some(name) = non_empty(status.release_name.as_deref()) {
+        output.push_str(&format!("Release: {name}\n"));
+    }
+    if let Some(url) = non_empty(status.release_url.as_deref()) {
+        output.push_str(&format!("URL: {url}\n"));
+    }
+    if let Some(published_at) = non_empty(status.published_at.as_deref()) {
+        output.push_str(&format!("Published: {published_at}\n"));
+    }
+    if let Some(body) = non_empty(status.release_body.as_deref()) {
+        output.push_str("\nChanges:\n");
+        output.push_str(&truncate_release_body(body, CLI_CHANGE_LIMIT));
+        output.push('\n');
+    }
+    if status.is_newer {
+        output.push_str("\nInstall/upgrade:\n");
+        output.push_str(INSTALL_HINT);
+        output.push('\n');
+    }
+    output
+}
+
+pub fn render_update_notification(status: &UpdateStatus) -> String {
+    if !status.is_newer {
+        return render_update_cli(status);
+    }
+
+    let mut output = String::new();
+    output.push_str("Lucarne update available\n");
+    output.push_str(&format!("Current: {}\n", status.current_version));
+    if let Some(latest_version) = &status.latest_version {
+        output.push_str(&format!("Latest: {latest_version}\n"));
+    }
+    if let Some(name) = non_empty(status.release_name.as_deref()) {
+        output.push_str(&format!("Release: {name}\n"));
+    }
+    if let Some(url) = non_empty(status.release_url.as_deref()) {
+        output.push_str(&format!("URL: {url}\n"));
+    }
+    if let Some(published_at) = non_empty(status.published_at.as_deref()) {
+        output.push_str(&format!("Published: {published_at}\n"));
+    }
+    if let Some(body) = non_empty(status.release_body.as_deref()) {
+        output.push_str("\nChanges:\n");
+        output.push_str(&truncate_release_body(body, NOTIFICATION_CHANGE_LIMIT));
+        output.push('\n');
+    }
+    output.push_str("\nInstall/upgrade:\n");
+    output.push_str(INSTALL_HINT);
+    output
+}
+
+pub fn render_doctor_message(status: &UpdateStatus) -> (crate::doctor::CheckLevel, String) {
+    if !status.automatic_checks_enabled {
+        return (
+            crate::doctor::CheckLevel::Ok,
+            "update checks disabled by config".to_string(),
+        );
+    }
+
+    if status.is_newer {
+        let latest = status.latest_version.as_deref().unwrap_or("unknown");
+        let url = status
+            .release_url
+            .as_deref()
+            .unwrap_or("release URL unavailable");
+        return (
+            crate::doctor::CheckLevel::Warn,
+            format!("update {latest} available: {url}"),
+        );
+    }
+
+    if let Some(latest) = &status.latest_version {
+        return (
+            crate::doctor::CheckLevel::Ok,
+            format!(
+                "current version {} (latest {latest})",
+                status.current_version
+            ),
+        );
+    }
+
+    (
+        crate::doctor::CheckLevel::Warn,
+        "no stable GitHub release found".to_string(),
+    )
+}
+
+fn non_empty(value: Option<&str>) -> Option<&str> {
+    value.and_then(|value| {
+        let trimmed = value.trim();
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(value)
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn newer_status() -> UpdateStatus {
+        UpdateStatus {
+            current_version: "0.1.0".to_string(),
+            latest_version: Some("0.2.0".to_string()),
+            release_name: Some("Lucarne 0.2.0".to_string()),
+            release_url: Some("https://github.com/tuchg/Lucarne/releases/tag/v0.2.0".to_string()),
+            published_at: Some("2026-05-21T00:00:00Z".to_string()),
+            release_body: Some("Fixed bugs and added features".to_string()),
+            is_newer: true,
+            automatic_checks_enabled: true,
+        }
+    }
+
+    #[test]
+    fn truncation_appends_marker_when_over_limit() {
+        assert_eq!(truncate_release_body("abcdef", 3), "abc...(truncated)");
+    }
+
+    #[test]
+    fn cli_output_includes_update_details_and_install_hint() {
+        let output = render_update_cli(&newer_status());
+        assert!(output.contains("0.1.0"));
+        assert!(output.contains("0.2.0"));
+        assert!(output.contains("Lucarne 0.2.0"));
+        assert!(output.contains("https://github.com/tuchg/Lucarne/releases/tag/v0.2.0"));
+        assert!(output.contains("curl -fsSL"));
+        assert!(output.contains("PowerShell"));
+    }
+
+    #[test]
+    fn cli_output_for_current_status_says_current() {
+        let mut status = newer_status();
+        status.current_version = "0.2.0".to_string();
+        status.is_newer = false;
+        let output = render_update_cli(&status);
+        assert!(output.contains("up to date") || output.contains("current"));
+    }
+
+    #[test]
+    fn notification_output_includes_update_details_and_truncated_changes() {
+        let mut status = newer_status();
+        status.release_body = Some("x".repeat(2_000));
+        let output = render_update_notification(&status);
+        assert!(output.contains("0.1.0"));
+        assert!(output.contains("0.2.0"));
+        assert!(output.contains("Lucarne 0.2.0"));
+        assert!(output.contains("...(truncated)"));
+    }
+}

--- a/crates/lucarned-ctl/src/updates/state.rs
+++ b/crates/lucarned-ctl/src/updates/state.rs
@@ -1,0 +1,166 @@
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct UpdateState {
+    pub last_checked_at_unix_secs: Option<u64>,
+    pub last_latest_version: Option<String>,
+    pub last_latest_url: Option<String>,
+    pub last_notified_version: Option<String>,
+    pub last_notified_at_unix_secs: Option<u64>,
+}
+
+#[derive(Debug, Clone)]
+pub struct UpdateStateStore {
+    path: PathBuf,
+}
+
+impl UpdateStateStore {
+    pub fn new(path: PathBuf) -> Self {
+        Self { path }
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    pub fn load(&self) -> Result<UpdateState, io::Error> {
+        let raw = match fs::read_to_string(&self.path) {
+            Ok(raw) => raw,
+            Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(UpdateState::default()),
+            Err(err) => return Err(err),
+        };
+        serde_json::from_str(&raw).map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))
+    }
+
+    pub fn save(&self, state: &UpdateState) -> Result<(), io::Error> {
+        if let Some(parent) = self.path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+
+        let parent = self.path.parent().unwrap_or_else(|| Path::new("."));
+        let file_name = self
+            .path
+            .file_name()
+            .map(|name| name.to_string_lossy())
+            .unwrap_or_else(|| "update-state.json".into());
+        static NEXT_TMP_ID: AtomicU64 = AtomicU64::new(0);
+        let tmp_id = NEXT_TMP_ID.fetch_add(1, Ordering::Relaxed);
+        let tmp_path = parent.join(format!(".{file_name}.tmp-{}-{tmp_id}", std::process::id()));
+        let bytes = serde_json::to_vec_pretty(state)
+            .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
+
+        let result = (|| {
+            let mut file = fs::File::create(&tmp_path)?;
+            file.write_all(&bytes)?;
+            file.write_all(b"\n")?;
+            file.sync_all()?;
+            drop(file);
+            fs::rename(&tmp_path, &self.path)
+        })();
+
+        if result.is_err() {
+            let _ = fs::remove_file(&tmp_path);
+        }
+        result
+    }
+}
+
+pub fn should_notify(
+    state: &UpdateState,
+    latest_version: &str,
+    now_unix_secs: u64,
+    remind_interval_secs: u64,
+) -> bool {
+    if state.last_notified_version.as_deref() != Some(latest_version) {
+        return true;
+    }
+
+    let Some(last_notified_at) = state.last_notified_at_unix_secs else {
+        return true;
+    };
+
+    now_unix_secs.saturating_sub(last_notified_at) >= remind_interval_secs
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temp_state_path(name: &str) -> PathBuf {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!(
+            "lucarned-ctl-update-state-{name}-{}-{unique}.json",
+            std::process::id()
+        ))
+    }
+
+    #[test]
+    fn missing_file_loads_default() {
+        let store = UpdateStateStore::new(temp_state_path("missing"));
+        assert_eq!(store.load().unwrap(), UpdateState::default());
+    }
+
+    #[test]
+    fn malformed_file_returns_error() {
+        let path = temp_state_path("malformed");
+        fs::write(&path, "not json").unwrap();
+        let store = UpdateStateStore::new(path.clone());
+        assert!(store.load().is_err());
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    fn save_then_load_round_trips() {
+        let path = temp_state_path("roundtrip");
+        let store = UpdateStateStore::new(path.clone());
+        let state = UpdateState {
+            last_checked_at_unix_secs: Some(10),
+            last_latest_version: Some("0.2.0".to_string()),
+            last_latest_url: Some("https://example.invalid/release".to_string()),
+            last_notified_version: Some("0.2.0".to_string()),
+            last_notified_at_unix_secs: Some(11),
+        };
+
+        store.save(&state).unwrap();
+        assert_eq!(store.load().unwrap(), state);
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    fn same_version_inside_interval_suppresses() {
+        let state = UpdateState {
+            last_notified_version: Some("0.2.0".to_string()),
+            last_notified_at_unix_secs: Some(100),
+            ..UpdateState::default()
+        };
+        assert!(!should_notify(&state, "0.2.0", 150, 100));
+    }
+
+    #[test]
+    fn same_version_after_interval_notifies() {
+        let state = UpdateState {
+            last_notified_version: Some("0.2.0".to_string()),
+            last_notified_at_unix_secs: Some(100),
+            ..UpdateState::default()
+        };
+        assert!(should_notify(&state, "0.2.0", 201, 100));
+    }
+
+    #[test]
+    fn different_version_notifies_immediately() {
+        let state = UpdateState {
+            last_notified_version: Some("0.2.0".to_string()),
+            last_notified_at_unix_secs: Some(100),
+            ..UpdateState::default()
+        };
+        assert!(should_notify(&state, "0.3.0", 101, 100));
+    }
+}

--- a/crates/lucarned-ctl/src/updates/version.rs
+++ b/crates/lucarned-ctl/src/updates/version.rs
@@ -1,0 +1,33 @@
+use semver::Version;
+
+pub fn normalize_tag(tag: &str) -> &str {
+    let trimmed = tag.trim();
+    trimmed.strip_prefix('v').unwrap_or(trimmed)
+}
+
+pub fn parse_version(value: &str) -> Result<Version, semver::Error> {
+    Version::parse(normalize_tag(value))
+}
+
+pub fn is_newer_version(current: &str, latest_tag: &str) -> Result<bool, semver::Error> {
+    Ok(parse_version(latest_tag)? > parse_version(current)?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strips_single_v_prefix_and_compares_versions() {
+        assert_eq!(normalize_tag("v0.2.0"), "0.2.0");
+        assert_eq!(normalize_tag("0.2.0"), "0.2.0");
+        assert!(is_newer_version("0.1.0", "v0.2.0").unwrap());
+        assert!(!is_newer_version("0.2.0", "v0.2.0").unwrap());
+        assert!(!is_newer_version("0.3.0", "v0.2.0").unwrap());
+    }
+
+    #[test]
+    fn invalid_latest_version_is_an_error() {
+        assert!(is_newer_version("0.1.0", "nightly").is_err());
+    }
+}

--- a/crates/lucarned/Cargo.toml
+++ b/crates/lucarned/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/main.rs"
 [dependencies]
 async-trait = { workspace = true }
 lucarne = { path = "../lucarne" }
-lucarned-ctl = { path = "../lucarned-ctl" }
+lucarned-ctl = { path = "../lucarned-ctl", features = ["updates"] }
 lucarne-adapter = { path = "../lucarne-adapter" }
 lucarne-telegram = { path = "../lucarne-telegram" }
 lucarne-wechat = { path = "../lucarne-wechat" }

--- a/crates/lucarned/src/main.rs
+++ b/crates/lucarned/src/main.rs
@@ -9,10 +9,12 @@ use lucarne::{default_lucarned_home_dir, default_state_db_path, CoreOptions, Luc
 use lucarne_adapter::{
     default_http_client, AdapterConfig, AdapterContext, AdapterError, AdapterPlugin,
     AdapterRegistry, AdapterResult, AdapterStatusReader, AdapterSupervisorHandle,
-    AdapterSupervisorOptions, GlobalConfigPersistence, GlobalConfigUpdate,
+    AdapterSupervisorOptions, GlobalConfigPersistence, GlobalConfigUpdate, SystemNotification,
+    SystemNotificationBus, SystemUpdateNotification,
 };
 use lucarne_telegram::telegram_plugin;
 use lucarne_wechat::wechat_plugin;
+use lucarned_ctl::updates::{UpdateNotice, UpdateRuntime, UpdateStateStore};
 use serde::Deserialize;
 use tokio::sync::watch;
 use tracing::{info, warn};
@@ -53,6 +55,13 @@ logging:
 health:
   enabled: false
   addr: 127.0.0.1:7766
+
+updates:
+  enabled: true
+  notify: true
+  check_interval_hours: 24
+  remind_interval_hours: 24
+  repository: tuchg/Lucarne
 
 turn:
   inactivity_secs: 1800
@@ -120,9 +129,24 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     match command {
         lucarned_ctl::Command::RunDaemon => run_daemon().await,
         lucarned_ctl::Command::Init => onboarding::run_interactive_init().await,
+        lucarned_ctl::Command::Doctor | lucarned_ctl::Command::Update => {
+            run_ctl_network_command(command).await
+        }
         command => lucarned_ctl::run(command)
             .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err).into()),
     }
+}
+
+async fn run_ctl_network_command(
+    command: lucarned_ctl::Command,
+) -> Result<(), Box<dyn std::error::Error>> {
+    dotenvy::dotenv().ok();
+    let (file_config, update_config_warning) = load_ctl_update_config();
+    let update_config = update_config_from_file(&file_config);
+    let client = default_http_client()?;
+    lucarned_ctl::run_async(command, &client, update_config, update_config_warning)
+        .await
+        .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err).into())
 }
 
 async fn run_daemon() -> Result<(), Box<dyn std::error::Error>> {
@@ -167,9 +191,14 @@ async fn run_daemon() -> Result<(), Box<dyn std::error::Error>> {
     let global_config_persistence = config_path.as_ref().map(|path| {
         Arc::new(YamlGlobalConfigPersistence::new(path.clone())) as Arc<dyn GlobalConfigPersistence>
     });
+    let http_client = default_http_client()?;
+    let system_notifications = SystemNotificationBus::new(32);
+    let update_config = update_config_from_file(&file_config);
+    let update_state_path = update_state_path();
+    let mut update_runtime =
+        UpdateRuntime::new(update_config, UpdateStateStore::new(update_state_path));
 
     let (mut adapter_supervisor, adapter_status_reader) = if enabled_adapter_count > 0 {
-        let http_client = default_http_client()?;
         lucarne::memory_profile_snapshot!("lucarned.main.before_supervise_enabled");
         let supervisor = registry
             .supervise_enabled(
@@ -177,7 +206,8 @@ async fn run_daemon() -> Result<(), Box<dyn std::error::Error>> {
                     core: Arc::clone(&core),
                     config: Arc::clone(&config),
                     shutdown: shutdown_rx,
-                    http_client,
+                    http_client: http_client.clone(),
+                    system_notifications: system_notifications.clone(),
                     global_config_persistence: global_config_persistence.clone(),
                 },
                 AdapterSupervisorOptions::default(),
@@ -213,7 +243,13 @@ async fn run_daemon() -> Result<(), Box<dyn std::error::Error>> {
     );
     lucarne::memory_profile_snapshot!("lucarned.main.before_wait");
 
-    let fatal_error = wait_for_shutdown_or_adapter_fatal(adapter_supervisor.as_mut()).await;
+    let fatal_error = wait_for_shutdown_or_adapter_fatal(
+        adapter_supervisor.as_mut(),
+        &mut update_runtime,
+        &http_client,
+        &system_notifications,
+    )
+    .await;
     if let Some(fatal) = fatal_error {
         let _ = shutdown_tx.send(true);
         return Err(format!("adapter {} fatal: {}", fatal.id, fatal.error).into());
@@ -272,23 +308,77 @@ fn init_tracing(file_config: &LucarnedFileConfig) -> Result<(), Box<dyn std::err
 }
 
 async fn wait_for_shutdown_or_adapter_fatal(
-    adapter_supervisor: Option<&mut AdapterSupervisorHandle>,
+    mut adapter_supervisor: Option<&mut AdapterSupervisorHandle>,
+    update_runtime: &mut UpdateRuntime,
+    http_client: &reqwest::Client,
+    system_notifications: &SystemNotificationBus,
 ) -> Option<lucarne_adapter::AdapterFatal> {
-    if let Some(adapter_supervisor) = adapter_supervisor {
-        tokio::select! {
-            fatal = adapter_supervisor.next_fatal() => fatal,
-            signal = tokio::signal::ctrl_c() => {
-                if let Err(err) = signal {
-                    warn!(error = %err, "failed to wait for ctrl-c signal; shutting down");
+    loop {
+        if let Some(adapter_supervisor) = adapter_supervisor.as_deref_mut() {
+            tokio::select! {
+                fatal = adapter_supervisor.next_fatal() => return fatal,
+                signal = tokio::signal::ctrl_c() => {
+                    if let Err(err) = signal {
+                        warn!(error = %err, "failed to wait for ctrl-c signal; shutting down");
+                    }
+                    return None;
                 }
-                None
+                tick = update_runtime.next_tick(http_client, env!("CARGO_PKG_VERSION")), if update_runtime.enabled() => {
+                    handle_update_runtime_tick(system_notifications, update_runtime, tick);
+                }
+            }
+        } else {
+            tokio::select! {
+                signal = tokio::signal::ctrl_c() => {
+                    if let Err(err) = signal {
+                        warn!(error = %err, "failed to wait for ctrl-c signal; shutting down");
+                    }
+                    return None;
+                }
+                tick = update_runtime.next_tick(http_client, env!("CARGO_PKG_VERSION")), if update_runtime.enabled() => {
+                    handle_update_runtime_tick(system_notifications, update_runtime, tick);
+                }
             }
         }
-    } else {
-        if let Err(err) = tokio::signal::ctrl_c().await {
-            warn!(error = %err, "failed to wait for ctrl-c signal; shutting down");
+    }
+}
+
+fn handle_update_runtime_tick(
+    system_notifications: &SystemNotificationBus,
+    update_runtime: &UpdateRuntime,
+    tick: lucarned_ctl::updates::UpdateRuntimeTick,
+) {
+    for warning in tick.warnings {
+        warn!(message = %warning, "update check warning");
+    }
+    send_update_system_notification(system_notifications, update_runtime, tick.notice);
+}
+
+fn send_update_system_notification(
+    system_notifications: &SystemNotificationBus,
+    update_runtime: &UpdateRuntime,
+    notice: Option<UpdateNotice>,
+) {
+    if let Some(notice) = notice {
+        let notification = SystemNotification::UpdateAvailable(SystemUpdateNotification {
+            current_version: notice.current_version.clone(),
+            latest_version: notice.latest_version.clone(),
+            release_name: notice.release_name.clone(),
+            release_url: notice.release_url.clone(),
+            published_at: notice.published_at.clone(),
+            body_markdown: notice.body_markdown.clone(),
+            install_hint: notice.install_hint.clone(),
+        });
+        let receivers = system_notifications.send(notification);
+        if receivers > 0 {
+            update_runtime.record_notice_delivered(&notice);
+            info!(receivers, "sent update system notification");
+        } else {
+            warn!(
+                latest_version = %notice.latest_version,
+                "update notification skipped because no adapters were subscribed"
+            );
         }
-        None
     }
 }
 
@@ -322,6 +412,8 @@ struct LucarnedFileConfig {
     #[serde(default)]
     health: HealthFileConfig,
     #[serde(default)]
+    updates: UpdateFileConfig,
+    #[serde(default)]
     turn: TurnFileConfig,
     #[serde(default)]
     session: SessionFileConfig,
@@ -348,6 +440,15 @@ struct LoggingFileConfig {
 struct HealthFileConfig {
     enabled: Option<bool>,
     addr: Option<String>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize)]
+struct UpdateFileConfig {
+    enabled: Option<bool>,
+    notify: Option<bool>,
+    check_interval_hours: Option<u64>,
+    remind_interval_hours: Option<u64>,
+    repository: Option<String>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize)]
@@ -455,6 +556,64 @@ fn core_options_from_config(
 
 fn env_secs(name: &str) -> Option<u64> {
     std::env::var(name).ok()?.parse().ok()
+}
+
+fn update_config_from_file(config: &LucarnedFileConfig) -> lucarned_ctl::updates::UpdateConfig {
+    update_config_from_file_with_env(config, |name| std::env::var(name).ok())
+}
+
+fn update_state_path() -> PathBuf {
+    default_lucarned_home_dir()
+        .map(|home| home.join("update-state.json"))
+        .unwrap_or_else(|| PathBuf::from("update-state.json"))
+}
+
+fn update_config_from_file_with_env<F>(
+    config: &LucarnedFileConfig,
+    env: F,
+) -> lucarned_ctl::updates::UpdateConfig
+where
+    F: Fn(&str) -> Option<String>,
+{
+    let defaults = lucarned_ctl::updates::UpdateConfig::default();
+    lucarned_ctl::updates::UpdateConfig {
+        enabled: env_bool(&env, "LUCARNED_UPDATES_ENABLED")
+            .or(config.updates.enabled)
+            .unwrap_or(defaults.enabled),
+        notify: env_bool(&env, "LUCARNED_UPDATES_NOTIFY")
+            .or(config.updates.notify)
+            .unwrap_or(defaults.notify),
+        check_interval: env_hours(&env, "LUCARNED_UPDATES_CHECK_INTERVAL_HOURS")
+            .or(config.updates.check_interval_hours)
+            .map(hours_to_duration)
+            .unwrap_or(defaults.check_interval),
+        remind_interval: env_hours(&env, "LUCARNED_UPDATES_REMIND_INTERVAL_HOURS")
+            .or(config.updates.remind_interval_hours)
+            .map(hours_to_duration)
+            .unwrap_or(defaults.remind_interval),
+        repository: env("LUCARNED_UPDATES_REPOSITORY")
+            .or_else(|| config.updates.repository.clone())
+            .unwrap_or(defaults.repository),
+        startup_delay: defaults.startup_delay,
+    }
+}
+
+fn env_bool<F>(env: &F, name: &str) -> Option<bool>
+where
+    F: Fn(&str) -> Option<String>,
+{
+    env(name).as_deref().and_then(parse_bool)
+}
+
+fn env_hours<F>(env: &F, name: &str) -> Option<u64>
+where
+    F: Fn(&str) -> Option<String>,
+{
+    env(name)?.parse().ok()
+}
+
+fn hours_to_duration(hours: u64) -> Duration {
+    Duration::from_secs(hours.max(1).saturating_mul(60 * 60))
 }
 
 fn validate_core_options(options: &CoreOptions) -> Result<(), Box<dyn std::error::Error>> {
@@ -654,6 +813,30 @@ fn resolve_config_path() -> Result<Option<PathBuf>, Box<dyn std::error::Error>> 
     let path = default_config_path_in(&home);
     ensure_default_config_file(&path)?;
     Ok(Some(path))
+}
+
+fn load_ctl_update_config() -> (LucarnedFileConfig, Option<String>) {
+    let Some(path) = existing_config_path_for_ctl_command() else {
+        return (LucarnedFileConfig::default(), None);
+    };
+    match LucarnedFileConfig::from_path_opt(Some(&path)) {
+        Ok(config) => (config, None),
+        Err(err) => (
+            LucarnedFileConfig::default(),
+            Some(format!(
+                "{} could not be read as lucarned config: {err}",
+                path.display()
+            )),
+        ),
+    }
+}
+
+fn existing_config_path_for_ctl_command() -> Option<PathBuf> {
+    explicit_config_path().or_else(|| {
+        default_lucarned_home_dir()
+            .map(|home| default_config_path_in(&home))
+            .filter(|path| path.exists())
+    })
 }
 
 fn explicit_config_path() -> Option<PathBuf> {
@@ -1023,6 +1206,9 @@ mod tests {
         assert!(raw.contains("global:"));
         assert!(raw.contains("bypass: false"));
         assert!(raw.contains("notifications: true"));
+        assert!(raw.contains("updates:"));
+        assert!(raw.contains("check_interval_hours: 24"));
+        assert!(raw.contains("repository: tuchg/Lucarne"));
         assert!(raw.contains("agents:"));
         assert!(raw.contains("  - claude"));
         assert!(raw.contains("  - codex"));
@@ -1066,6 +1252,14 @@ mod tests {
         assert_eq!(
             daemon_config.runtime_config.global.notifications,
             Some(true)
+        );
+        assert_eq!(daemon_config.updates.enabled, Some(true));
+        assert_eq!(daemon_config.updates.notify, Some(true));
+        assert_eq!(daemon_config.updates.check_interval_hours, Some(24));
+        assert_eq!(daemon_config.updates.remind_interval_hours, Some(24));
+        assert_eq!(
+            daemon_config.updates.repository.as_deref(),
+            Some("tuchg/Lucarne")
         );
 
         let adapter_config =
@@ -1128,6 +1322,60 @@ health:
         assert_eq!(config.logging.buffered_lines, Some(64));
         assert_eq!(config.health.enabled, Some(true));
         assert_eq!(config.health.addr.as_deref(), Some("127.0.0.1:7766"));
+    }
+
+    #[test]
+    fn lucarned_file_config_parses_update_settings() {
+        let config = LucarnedFileConfig::from_yaml_str(
+            r#"
+updates:
+  enabled: false
+  notify: false
+  check_interval_hours: 6
+  remind_interval_hours: 12
+  repository: owner/project
+"#,
+        )
+        .expect("parse lucarned update config");
+
+        assert_eq!(config.updates.enabled, Some(false));
+        assert_eq!(config.updates.notify, Some(false));
+        assert_eq!(config.updates.check_interval_hours, Some(6));
+        assert_eq!(config.updates.remind_interval_hours, Some(12));
+        assert_eq!(config.updates.repository.as_deref(), Some("owner/project"));
+    }
+
+    #[test]
+    fn update_config_defaults_clamps_hours_and_honors_env_overrides() {
+        let defaults = update_config_from_file_with_env(&LucarnedFileConfig::default(), |_| None);
+        assert!(defaults.enabled);
+        assert!(defaults.notify);
+        assert_eq!(defaults.check_interval, Duration::from_secs(24 * 60 * 60));
+        assert_eq!(defaults.remind_interval, Duration::from_secs(24 * 60 * 60));
+        assert_eq!(defaults.repository, "tuchg/Lucarne");
+
+        let config = LucarnedFileConfig::from_yaml_str(
+            r#"
+updates:
+  enabled: false
+  notify: false
+  check_interval_hours: 0
+  remind_interval_hours: 2
+  repository: file/repo
+"#,
+        )
+        .expect("parse update config");
+        let resolved = update_config_from_file_with_env(&config, |name| match name {
+            "LUCARNED_UPDATES_ENABLED" => Some("true".to_string()),
+            "LUCARNED_UPDATES_REPOSITORY" => Some("env/repo".to_string()),
+            _ => None,
+        });
+
+        assert!(resolved.enabled);
+        assert!(!resolved.notify);
+        assert_eq!(resolved.check_interval, Duration::from_secs(60 * 60));
+        assert_eq!(resolved.remind_interval, Duration::from_secs(2 * 60 * 60));
+        assert_eq!(resolved.repository, "env/repo");
     }
 
     #[tokio::test]
@@ -1498,19 +1746,51 @@ logging:
     fn daemon_exits_idle_before_opening_core_or_http_client() {
         let source = include_str!("main.rs");
         let production_source = source.split("#[cfg(test)]").next().unwrap_or(source);
-        let idle_exit = production_source
+        let run_daemon_source = production_source
+            .split("async fn run_daemon()")
+            .nth(1)
+            .and_then(|rest| rest.split("fn init_tracing").next())
+            .expect("run_daemon body");
+        let idle_exit = run_daemon_source
             .find("no adapters enabled; edit lucarned config to enable a channel")
             .expect("idle exit guidance log");
-        let open_sqlite = production_source
-            .find("LucarneCore::open_sqlite")
+        let open_core = run_daemon_source
+            .find("open_core_from_config")
             .expect("core open");
-        let http_client = production_source
+        let http_client = run_daemon_source
             .find("default_http_client()")
             .expect("http client creation");
 
-        assert!(production_source.contains("enabled_adapter_count == 0 && health_addr.is_none()"));
-        assert!(idle_exit < open_sqlite);
+        assert!(run_daemon_source.contains("enabled_adapter_count == 0 && health_addr.is_none()"));
+        assert!(idle_exit < open_core);
         assert!(idle_exit < http_client);
+    }
+
+    #[test]
+    fn daemon_creates_system_notification_bus_and_drives_update_runtime() {
+        let source = include_str!("main.rs");
+        let production_source = source.split("#[cfg(test)]").next().unwrap_or(source);
+        let run_daemon_source = production_source
+            .split("async fn run_daemon()")
+            .nth(1)
+            .and_then(|rest| rest.split("fn init_tracing").next())
+            .expect("run_daemon body");
+        let wait_source = production_source
+            .split("async fn wait_for_shutdown_or_adapter_fatal")
+            .nth(1)
+            .and_then(|rest| rest.split("fn register_if_enabled").next())
+            .expect("wait loop body");
+
+        assert!(run_daemon_source.contains("SystemNotificationBus::new(32)"));
+        assert!(run_daemon_source.contains("system_notifications.clone()"));
+        assert!(run_daemon_source.contains("UpdateRuntime::new"));
+        assert!(run_daemon_source.contains("UpdateStateStore::new(update_state_path)"));
+        assert!(run_daemon_source.contains("http_client.clone()"));
+        assert!(wait_source.contains("update_runtime.next_tick"));
+        assert!(wait_source.contains("SystemNotification::UpdateAvailable"));
+        assert!(wait_source.contains("system_notifications.send"));
+        assert!(wait_source.contains("sent update system notification"));
+        assert!(!wait_source.contains("tokio::spawn"));
     }
 
     #[test]

--- a/crates/lucarned/src/onboarding/config.rs
+++ b/crates/lucarned/src/onboarding/config.rs
@@ -237,6 +237,7 @@ struct ConfigYaml<'a> {
     state: StateYaml,
     logging: LoggingYaml,
     health: HealthYaml,
+    updates: UpdatesYaml,
     turn: TurnYaml,
     session: SessionYaml,
     config: RuntimeConfigYaml,
@@ -267,6 +268,13 @@ impl<'a> From<&'a InitConfigDraft> for ConfigYaml<'a> {
             health: HealthYaml {
                 enabled: false,
                 addr: DEFAULT_HEALTH_ADDR,
+            },
+            updates: UpdatesYaml {
+                enabled: true,
+                notify: true,
+                check_interval_hours: 24,
+                remind_interval_hours: 24,
+                repository: "tuchg/Lucarne",
             },
             turn: TurnYaml {
                 inactivity_secs: 1800,
@@ -308,6 +316,15 @@ struct LoggingYaml {
 struct HealthYaml {
     enabled: bool,
     addr: &'static str,
+}
+
+#[derive(Serialize)]
+struct UpdatesYaml {
+    enabled: bool,
+    notify: bool,
+    check_interval_hours: u8,
+    remind_interval_hours: u8,
+    repository: &'static str,
 }
 
 #[derive(Serialize)]
@@ -458,6 +475,9 @@ mod tests {
         assert!(yaml.contains("global:"));
         assert!(yaml.contains("bypass: false"));
         assert!(yaml.contains("notifications: true"));
+        assert!(yaml.contains("updates:"));
+        assert!(yaml.contains("check_interval_hours: 24"));
+        assert!(yaml.contains("repository: tuchg/Lucarne"));
         assert!(yaml.contains("telegram:"));
         assert!(yaml.contains("wechat:"));
         assert!(yaml.contains("enabled: false"));

--- a/docs/superpowers/plans/2026-05-21-update-awareness.md
+++ b/docs/superpowers/plans/2026-05-21-update-awareness.md
@@ -1,0 +1,842 @@
+# Update Awareness Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add update awareness that checks GitHub Releases, reports status in `doctor`/`update`, and notifies Telegram/WeChat users without self-updating.
+
+**Architecture:** `lucarned-ctl` owns update config, release checking, version comparison, state throttling, and rendering behind an `updates` feature. `lucarned` creates the shared `lucarne_adapter::default_http_client()`, drives `UpdateRuntime` from the existing main wait loop, and forwards generic `SystemNotification` values to adapters. Telegram and WeChat consume notifications in their existing long-lived loops; no update-specific task is spawned.
+
+**Tech Stack:** Rust, Tokio, reqwest, serde/serde_json/serde_yaml, semver, existing lucarne-adapter/telegram/wechat channel abstractions.
+
+---
+
+## File Structure
+
+- `crates/lucarned-ctl/Cargo.toml` — add optional `updates` feature and optional dependencies.
+- `crates/lucarned-ctl/src/updates/mod.rs` — public update facade: config, status, notices, checker entrypoints, runtime.
+- `crates/lucarned-ctl/src/updates/github.rs` — GitHub latest release request and JSON parsing.
+- `crates/lucarned-ctl/src/updates/version.rs` — `v` prefix normalization and semver comparison.
+- `crates/lucarned-ctl/src/updates/state.rs` — `update-state.json` persistence and notification throttling.
+- `crates/lucarned-ctl/src/updates/render.rs` — CLI, doctor, and notification text rendering.
+- `crates/lucarned-ctl/src/args.rs` — add `update` command parser/usage/tests.
+- `crates/lucarned-ctl/src/doctor.rs` — add async update-aware doctor helper behind feature.
+- `crates/lucarned-ctl/src/lib.rs` — export update module behind feature and expose async run entrypoint.
+- `crates/lucarne-adapter/src/lib.rs` — add channel-agnostic `SystemNotification` bus and context field.
+- `crates/lucarned/Cargo.toml` — enable `lucarned-ctl/updates`.
+- `crates/lucarned/src/main.rs` — parse update config, create shared client once, route `update`/async doctor, drive update runtime in wait loop.
+- `crates/lucarned/src/onboarding/config.rs` — render default `updates` config.
+- `crates/lucarne-telegram/src/adapter.rs` — subscribe to system notifications and pass receiver to bot.
+- `crates/lucarne-telegram/src/bot.rs` — deliver update notices to entry chat.
+- `crates/lucarne-wechat/src/adapter.rs` — subscribe to system notifications and pass receiver to service.
+- `crates/lucarne-wechat/src/service.rs` — deliver update notices to configured/known users.
+- `README.md` — document update checks, opt-out, manual update command.
+
+---
+
+### Task 1: Build `lucarned-ctl` update core
+
+**Files:**
+- Modify: `crates/lucarned-ctl/Cargo.toml`
+- Modify: `crates/lucarned-ctl/src/lib.rs`
+- Create: `crates/lucarned-ctl/src/updates/mod.rs`
+- Create: `crates/lucarned-ctl/src/updates/github.rs`
+- Create: `crates/lucarned-ctl/src/updates/version.rs`
+- Create: `crates/lucarned-ctl/src/updates/state.rs`
+- Create: `crates/lucarned-ctl/src/updates/render.rs`
+
+- [ ] **Step 1: Add feature-gated dependencies**
+
+Add to `crates/lucarned-ctl/Cargo.toml`:
+
+```toml
+[features]
+default = []
+updates = [
+    "dep:reqwest",
+    "dep:semver",
+    "dep:serde",
+    "dep:serde_json",
+    "dep:tokio",
+]
+
+[dependencies]
+reqwest = { workspace = true, optional = true }
+semver = { version = "1", optional = true }
+serde = { workspace = true, optional = true }
+serde_json = { workspace = true, optional = true }
+tokio = { workspace = true, optional = true }
+```
+
+Do not add non-optional dependencies to `lucarned-ctl`.
+
+- [ ] **Step 2: Export updates module behind feature**
+
+Add to `crates/lucarned-ctl/src/lib.rs` near other modules:
+
+```rust
+#[cfg(feature = "updates")]
+pub mod updates;
+```
+
+- [ ] **Step 3: Implement version comparison tests first**
+
+Create `crates/lucarned-ctl/src/updates/version.rs` with tests for:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strips_single_v_prefix_and_compares_versions() {
+        assert_eq!(normalize_tag("v0.2.0"), "0.2.0");
+        assert_eq!(normalize_tag("0.2.0"), "0.2.0");
+        assert!(is_newer_version("0.1.0", "v0.2.0").unwrap());
+        assert!(!is_newer_version("0.2.0", "v0.2.0").unwrap());
+        assert!(!is_newer_version("0.3.0", "v0.2.0").unwrap());
+    }
+
+    #[test]
+    fn invalid_latest_version_is_an_error() {
+        assert!(is_newer_version("0.1.0", "nightly").is_err());
+    }
+}
+```
+
+Then implement:
+
+```rust
+use semver::Version;
+
+pub fn normalize_tag(tag: &str) -> &str {
+    tag.trim().strip_prefix('v').unwrap_or_else(|| tag.trim())
+}
+
+pub fn parse_version(value: &str) -> Result<Version, semver::Error> {
+    Version::parse(normalize_tag(value))
+}
+
+pub fn is_newer_version(current: &str, latest_tag: &str) -> Result<bool, semver::Error> {
+    Ok(parse_version(latest_tag)? > parse_version(current)?)
+}
+```
+
+- [ ] **Step 4: Implement GitHub release parser and checker**
+
+Create `crates/lucarned-ctl/src/updates/github.rs` with:
+
+```rust
+use serde::Deserialize;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GithubRelease {
+    pub tag_name: String,
+    pub name: String,
+    pub html_url: String,
+    pub body: String,
+    pub published_at: Option<String>,
+    pub draft: bool,
+    pub prerelease: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct GithubReleaseJson {
+    tag_name: String,
+    #[serde(default)]
+    name: String,
+    html_url: String,
+    #[serde(default)]
+    body: String,
+    published_at: Option<String>,
+    #[serde(default)]
+    draft: bool,
+    #[serde(default)]
+    prerelease: bool,
+}
+```
+
+Expose:
+
+```rust
+pub fn parse_release_json(raw: &str) -> Result<GithubRelease, serde_json::Error>;
+pub async fn fetch_latest_release(
+    client: &reqwest::Client,
+    repository: &str,
+    user_agent: &str,
+) -> Result<Option<GithubRelease>, UpdateError>;
+```
+
+Rules:
+- URL: `https://api.github.com/repos/{repository}/releases/latest`.
+- Reject repository strings not shaped as `owner/repo`.
+- Add headers `User-Agent` and `Accept: application/vnd.github+json`.
+- Non-success HTTP is transient `UpdateError::HttpStatus(status)`.
+- If `draft || prerelease`, return `Ok(None)`.
+- Read response text through reqwest; if body length exceeds 128 KiB, return `UpdateError::ResponseTooLarge`.
+
+Tests: use `parse_release_json` for normal release, prerelease, draft, missing optional fields.
+
+- [ ] **Step 5: Implement state persistence and throttling**
+
+Create `crates/lucarned-ctl/src/updates/state.rs`:
+
+```rust
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct UpdateState {
+    pub last_checked_at_unix_secs: Option<u64>,
+    pub last_latest_version: Option<String>,
+    pub last_latest_url: Option<String>,
+    pub last_notified_version: Option<String>,
+    pub last_notified_at_unix_secs: Option<u64>,
+}
+
+#[derive(Debug, Clone)]
+pub struct UpdateStateStore {
+    path: PathBuf,
+}
+```
+
+Implement:
+
+```rust
+impl UpdateStateStore {
+    pub fn new(path: PathBuf) -> Self;
+    pub fn path(&self) -> &Path;
+    pub fn load(&self) -> Result<UpdateState, std::io::Error>;
+    pub fn save(&self, state: &UpdateState) -> Result<(), std::io::Error>;
+}
+
+pub fn should_notify(
+    state: &UpdateState,
+    latest_version: &str,
+    now_unix_secs: u64,
+    remind_interval_secs: u64,
+) -> bool;
+```
+
+Save atomically: create parent, write `.<file>.tmp-<pid>`, rename.
+
+Tests:
+- missing file loads default,
+- malformed file returns error from `load`,
+- save then load round-trips,
+- same version inside interval suppresses,
+- same version after interval notifies,
+- different version notifies immediately.
+
+- [ ] **Step 6: Implement render helpers**
+
+Create `crates/lucarned-ctl/src/updates/render.rs` with:
+
+```rust
+pub const INSTALL_HINT: &str = "macOS/Linux:\n  curl -fsSL https://github.com/tuchg/Lucarne/releases/latest/download/lucarned-installer.sh | sh\n\nWindows PowerShell:\n  irm https://github.com/tuchg/Lucarne/releases/latest/download/lucarned-installer.ps1 | iex\n\nIf installed through a package manager, upgrade with that package manager.";
+
+pub fn truncate_release_body(body: &str, max_chars: usize) -> String;
+pub fn render_update_cli(status: &UpdateStatus) -> String;
+pub fn render_update_notification(status: &UpdateStatus) -> String;
+pub fn render_doctor_message(status: &UpdateStatus) -> (crate::doctor::CheckLevel, String);
+```
+
+Tests:
+- truncation appends `...(truncated)` when over limit,
+- CLI output includes current/latest/release/install hints,
+- current status says current,
+- notification output includes current/latest/release and truncated changes.
+
+- [ ] **Step 7: Implement public facade and runtime**
+
+Create `crates/lucarned-ctl/src/updates/mod.rs`:
+
+```rust
+mod github;
+mod render;
+mod state;
+mod version;
+
+pub use render::{render_update_cli, render_update_notification, INSTALL_HINT};
+pub use state::{UpdateState, UpdateStateStore};
+
+#[derive(Debug, Clone)]
+pub struct UpdateConfig {
+    pub enabled: bool,
+    pub notify: bool,
+    pub check_interval: std::time::Duration,
+    pub remind_interval: std::time::Duration,
+    pub repository: String,
+    pub startup_delay: std::time::Duration,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UpdateStatus {
+    pub current_version: String,
+    pub latest_version: Option<String>,
+    pub release_name: Option<String>,
+    pub release_url: Option<String>,
+    pub published_at: Option<String>,
+    pub release_body: Option<String>,
+    pub is_newer: bool,
+    pub automatic_checks_enabled: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UpdateNotice {
+    pub current_version: String,
+    pub latest_version: String,
+    pub release_name: String,
+    pub release_url: String,
+    pub published_at: Option<String>,
+    pub body_markdown: String,
+    pub install_hint: String,
+}
+```
+
+Implement:
+
+```rust
+impl Default for UpdateConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            notify: true,
+            check_interval: std::time::Duration::from_secs(24 * 60 * 60),
+            remind_interval: std::time::Duration::from_secs(24 * 60 * 60),
+            repository: "tuchg/Lucarne".to_string(),
+            startup_delay: std::time::Duration::from_secs(60),
+        }
+    }
+}
+
+pub async fn check_now(
+    client: &reqwest::Client,
+    config: &UpdateConfig,
+    current_version: &str,
+) -> Result<UpdateStatus, UpdateError>;
+
+pub struct UpdateRuntime { /* config, state_store, next_due */ }
+
+impl UpdateRuntime {
+    pub fn new(config: UpdateConfig, state_store: UpdateStateStore) -> Self;
+    pub fn enabled(&self) -> bool;
+    pub async fn next_notice(
+        &mut self,
+        client: &reqwest::Client,
+        current_version: &str,
+    ) -> Option<UpdateNotice>;
+}
+```
+
+`next_notice` must:
+- sleep until `next_due`,
+- set next due to `now + check_interval`,
+- wrap `check_now` in `tokio::time::timeout(Duration::from_secs(10), ...)`,
+- load state, update `last_checked_*`,
+- if newer and `notify` and `should_notify`, save `last_notified_*` and return notice,
+- never panic or return errors; log via `eprintln!` is not acceptable in library. Return `None` on error and let callers log later only if API exposes error. Prefer tracing-free ctl by keeping runtime quiet and tested through state.
+
+- [ ] **Step 8: Verify Task 1**
+
+Run:
+
+```bash
+cargo +nightly test -Zbuild-dir-new-layout -p lucarned-ctl --features updates
+cargo +nightly test -Zbuild-dir-new-layout -p lucarned-ctl --no-default-features
+```
+
+Expected: both pass.
+
+- [ ] **Step 9: Commit Task 1**
+
+```bash
+git add crates/lucarned-ctl Cargo.lock
+git commit -m "feat: add update check core"
+```
+
+---
+
+### Task 2: Add `update` CLI and update-aware `doctor`
+
+**Files:**
+- Modify: `crates/lucarned-ctl/src/args.rs`
+- Modify: `crates/lucarned-ctl/src/lib.rs`
+- Modify: `crates/lucarned-ctl/src/doctor.rs`
+- Modify: `crates/lucarned/src/main.rs`
+- Modify: `crates/lucarned/Cargo.toml`
+- Modify: `crates/lucarned/src/onboarding/config.rs`
+
+- [ ] **Step 1: Add parser tests**
+
+In `crates/lucarned-ctl/src/args.rs`, add to `parses_top_level_commands`:
+
+```rust
+assert_eq!(parse_words(&["lucarned", "update"]).unwrap(), Command::Update);
+```
+
+Add `Update` to `Command` enum and `usage()` after `doctor`.
+
+- [ ] **Step 2: Enable updates feature in daemon**
+
+Change `crates/lucarned/Cargo.toml`:
+
+```toml
+lucarned-ctl = { path = "../lucarned-ctl", features = ["updates"] }
+```
+
+- [ ] **Step 3: Add async ctl entrypoint**
+
+In `crates/lucarned-ctl/src/lib.rs`, keep existing sync `run` for non-network commands. Add behind feature:
+
+```rust
+#[cfg(feature = "updates")]
+pub async fn run_async(
+    command: Command,
+    client: &reqwest::Client,
+    update_config: updates::UpdateConfig,
+    update_state_path: std::path::PathBuf,
+) -> Result<(), String> {
+    match command {
+        Command::Doctor => doctor::run_doctor_async(client, update_config).await,
+        Command::Update => updates::run_update_command(client, update_config).await,
+        other => run(other),
+    }
+}
+```
+
+Also make sync `run(Command::Update)` return a clear error when feature is unavailable or route only through async path when feature is enabled.
+
+- [ ] **Step 4: Add doctor async helper**
+
+In `crates/lucarned-ctl/src/doctor.rs`:
+
+```rust
+#[cfg(feature = "updates")]
+pub async fn run_doctor_async(
+    client: &reqwest::Client,
+    update_config: crate::updates::UpdateConfig,
+) -> Result<(), String> {
+    let mut checks = collect_checks()?;
+    checks.push(update_check(client, update_config).await);
+    print_checks(&checks);
+    if checks.iter().any(|check| check.level == CheckLevel::Fail) {
+        Err("doctor found critical failures".to_string())
+    } else {
+        Ok(())
+    }
+}
+```
+
+Refactor current print loop into `fn print_checks(checks: &[Check])` so sync and async share it.
+
+`update_check` behavior:
+- if `!update_config.enabled`: `ok: update: checks disabled by config`,
+- if current: `ok: update: current version ...`,
+- if newer: `warn: update: <version> available: <url>`,
+- if error: `warn: update: check failed: <err>`.
+
+- [ ] **Step 5: Add config parsing in `lucarned main`**
+
+In `crates/lucarned/src/main.rs`, add to `DEFAULT_LUCARNED_CONFIG`:
+
+```yaml
+updates:
+  enabled: true
+  notify: true
+  check_interval_hours: 24
+  remind_interval_hours: 24
+  repository: tuchg/Lucarne
+```
+
+Add `updates: UpdateFileConfig` to `LucarnedFileConfig` and a helper:
+
+```rust
+#[derive(Clone, Debug, Default, Deserialize)]
+struct UpdateFileConfig {
+    enabled: Option<bool>,
+    notify: Option<bool>,
+    check_interval_hours: Option<u64>,
+    remind_interval_hours: Option<u64>,
+    repository: Option<String>,
+}
+
+#[cfg(feature = "updates")]
+fn update_config_from_file(config: &LucarnedFileConfig) -> lucarned_ctl::updates::UpdateConfig {
+    let defaults = lucarned_ctl::updates::UpdateConfig::default();
+    lucarned_ctl::updates::UpdateConfig {
+        enabled: env_bool("LUCARNED_UPDATES_ENABLED").or(config.updates.enabled).unwrap_or(defaults.enabled),
+        notify: env_bool("LUCARNED_UPDATES_NOTIFY").or(config.updates.notify).unwrap_or(defaults.notify),
+        check_interval: env_hours("LUCARNED_UPDATES_CHECK_INTERVAL_HOURS").or(config.updates.check_interval_hours).map(hours_to_duration).unwrap_or(defaults.check_interval),
+        remind_interval: env_hours("LUCARNED_UPDATES_REMIND_INTERVAL_HOURS").or(config.updates.remind_interval_hours).map(hours_to_duration).unwrap_or(defaults.remind_interval),
+        repository: std::env::var("LUCARNED_UPDATES_REPOSITORY").ok().or_else(|| config.updates.repository.clone()).unwrap_or(defaults.repository),
+        startup_delay: defaults.startup_delay,
+    }
+}
+```
+
+Clamp hour values below 1 to 1 hour.
+
+- [ ] **Step 6: Route CLI through shared client**
+
+In `main()`, for `Command::Doctor` and `Command::Update`, load dotenv/config, create `default_http_client()?`, and call `lucarned_ctl::run_async(...)`. Other sync commands keep current path.
+
+Do not create a client inside `lucarned-ctl`.
+
+- [ ] **Step 7: Render update config from `lucarned init`**
+
+In `crates/lucarned/src/onboarding/config.rs`, add an `updates: UpdatesYaml` field to `ConfigYaml` and render defaults:
+
+```rust
+#[derive(Serialize)]
+struct UpdatesYaml {
+    enabled: bool,
+    notify: bool,
+    check_interval_hours: u8,
+    remind_interval_hours: u8,
+    repository: &'static str,
+}
+```
+
+Assert in existing render tests that YAML contains `updates:`, `check_interval_hours: 24`, and `repository: tuchg/Lucarne`.
+
+- [ ] **Step 8: Verify Task 2**
+
+Run:
+
+```bash
+cargo +nightly test -Zbuild-dir-new-layout -p lucarned-ctl --features updates
+cargo +nightly test -Zbuild-dir-new-layout -p lucarned --quiet
+```
+
+Expected: pass.
+
+- [ ] **Step 9: Commit Task 2**
+
+```bash
+git add crates/lucarned-ctl crates/lucarned Cargo.lock
+git commit -m "feat: add update status commands"
+```
+
+---
+
+### Task 3: Add generic system notification bus and daemon update driver
+
+**Files:**
+- Modify: `crates/lucarne-adapter/src/lib.rs`
+- Modify: `crates/lucarned/src/main.rs`
+
+- [ ] **Step 1: Add adapter bus types and tests**
+
+In `crates/lucarne-adapter/src/lib.rs`, import broadcast:
+
+```rust
+use tokio::sync::{broadcast, mpsc, watch};
+```
+
+Add near `GlobalConfigUpdate`:
+
+```rust
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SystemNotification {
+    UpdateAvailable(SystemUpdateNotification),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SystemUpdateNotification {
+    pub current_version: String,
+    pub latest_version: String,
+    pub release_name: String,
+    pub release_url: String,
+    pub published_at: Option<String>,
+    pub body_markdown: String,
+    pub install_hint: String,
+}
+
+#[derive(Clone)]
+pub struct SystemNotificationBus {
+    tx: broadcast::Sender<SystemNotification>,
+}
+
+pub struct SystemNotificationReceiver {
+    rx: broadcast::Receiver<SystemNotification>,
+}
+```
+
+Implement:
+
+```rust
+impl SystemNotificationBus {
+    pub fn new(capacity: usize) -> Self;
+    pub fn subscribe(&self) -> SystemNotificationReceiver;
+    pub fn send(&self, notification: SystemNotification) -> usize;
+}
+
+impl SystemNotificationReceiver {
+    pub async fn recv(&mut self) -> Result<SystemNotification, broadcast::error::RecvError>;
+}
+```
+
+`send` returns `0` if there are no receivers or send fails.
+
+Add field to `AdapterContext`:
+
+```rust
+pub system_notifications: SystemNotificationBus,
+```
+
+Update tests/context constructors with `SystemNotificationBus::new(16)`.
+
+- [ ] **Step 2: Create and pass bus in daemon**
+
+In `run_daemon()`, create bus before supervising adapters:
+
+```rust
+let system_notifications = lucarne_adapter::SystemNotificationBus::new(32);
+```
+
+Pass `system_notifications.clone()` into `AdapterContext`.
+
+- [ ] **Step 3: Drive update runtime from main wait loop**
+
+Create update runtime in `run_daemon()` after file config is loaded and shared client exists:
+
+```rust
+let update_config = update_config_from_file(&file_config);
+let update_state_path = lucarned_ctl::paths::default_config_dir()?.join("update-state.json");
+let mut update_runtime = lucarned_ctl::updates::UpdateRuntime::new(
+    update_config,
+    lucarned_ctl::updates::UpdateStateStore::new(update_state_path),
+);
+```
+
+Move `default_http_client()` so one client is created once before both adapter and update usage.
+
+Update `wait_for_shutdown_or_adapter_fatal` to loop and include:
+
+```rust
+notice = update_runtime.next_notice(&http_client, env!("CARGO_PKG_VERSION")), if update_runtime.enabled() => {
+    if let Some(notice) = notice {
+        let notification = lucarne_adapter::SystemNotification::UpdateAvailable(
+            lucarne_adapter::SystemUpdateNotification {
+                current_version: notice.current_version,
+                latest_version: notice.latest_version,
+                release_name: notice.release_name,
+                release_url: notice.release_url,
+                published_at: notice.published_at,
+                body_markdown: notice.body_markdown,
+                install_hint: notice.install_hint,
+            },
+        );
+        let receivers = system_notifications.send(notification);
+        tracing::info!(receivers, "sent update system notification");
+    }
+}
+```
+
+Do not use `tokio::spawn` for update checking.
+
+- [ ] **Step 4: Verify Task 3**
+
+Run:
+
+```bash
+cargo +nightly test -Zbuild-dir-new-layout -p lucarne-adapter
+cargo +nightly test -Zbuild-dir-new-layout -p lucarned --quiet
+```
+
+Expected: pass.
+
+- [ ] **Step 5: Commit Task 3**
+
+```bash
+git add crates/lucarne-adapter crates/lucarned Cargo.lock
+git commit -m "feat: drive update notifications from daemon"
+```
+
+---
+
+### Task 4: Deliver system notifications through Telegram and WeChat
+
+**Files:**
+- Modify: `crates/lucarne-telegram/src/adapter.rs`
+- Modify: `crates/lucarne-telegram/src/bot.rs`
+- Modify: `crates/lucarne-wechat/src/adapter.rs`
+- Modify: `crates/lucarne-wechat/src/service.rs`
+
+- [ ] **Step 1: Telegram subscribes in adapter spawn**
+
+In `TelegramAdapterPlugin::spawn`, call:
+
+```rust
+let system_notifications = ctx.system_notifications.subscribe();
+```
+
+Pass receiver into `run_telegram_adapter_with_client_and_global_config_persistence`. Preserve existing public helper functions by creating a fresh bus and subscribing to it for callers that do not have daemon context.
+
+- [ ] **Step 2: Telegram bot handles notices in existing loop**
+
+Refactor `Bot::run` so it owns `mut system_notifications: SystemNotificationReceiver` and selects over channel events and system notifications in the same long-lived loop.
+
+Add:
+
+```rust
+async fn handle_system_notification(
+    &self,
+    notification: lucarne_adapter::SystemNotification,
+) -> Result<(), String> {
+    match notification {
+        lucarne_adapter::SystemNotification::UpdateAvailable(update) => {
+            let msg = OutgoingMessage::markdown(update.body_markdown);
+            send_with_fallback(&*self.channel, &self.entry, msg, "lucarned")
+                .await
+                .map(|_| ())
+                .map_err(|err| err.to_string())
+        }
+    }
+}
+```
+
+Use entry chat/root handle, not provider session binding.
+
+- [ ] **Step 3: WeChat subscribes in adapter spawn**
+
+In `WechatAdapterPlugin::spawn`, subscribe before spawning task and pass receiver into the service run path. Avoid adding receiver to `WechatServiceOptions` if it would break `Clone`; pass as a separate argument to `run_until_shutdown` or add a new method.
+
+- [ ] **Step 4: WeChat service handles notices in existing loop**
+
+In `WechatNotificationService::run_until_shutdown`, add a select branch for `system_notifications.recv()`.
+
+Add:
+
+```rust
+async fn deliver_system_notification(
+    &self,
+    notification: lucarne_adapter::SystemNotification,
+) -> Result<(), WechatError> {
+    match notification {
+        lucarne_adapter::SystemNotification::UpdateAvailable(update) => {
+            self.deliver_update_notification(&update.body_markdown).await
+        }
+    }
+}
+```
+
+`deliver_update_notification`:
+- calls `self.notification_users()`;
+- logs and returns `Ok(())` if empty;
+- for each user, calls `transport.context_for_user(&user_id).await?`;
+- sends `transport.send(&context, body).await`;
+- on rate limit, records rate limit and skips/queues only if a small system pending queue is added;
+- does not call `bind_receipt`, does not require `ProviderSessionId`, and does not use `WorkspaceId`.
+
+Keep it simple: log per-user failures and continue; return `Ok(())` unless all sends fail due a shared fatal transport error already represented by `WechatError`.
+
+- [ ] **Step 5: Add adapter delivery tests**
+
+Telegram test: use fake/recording channel or existing bot test helper to send `SystemNotification::UpdateAvailable` and assert one outbound markdown message to entry chat.
+
+WeChat test: use existing `FakeTransport`, initialize service with `initial_user_ids = vec!["user-1".into()]`, deliver a system notification, and assert visible sent text contains `Lucarne update available` and no provider/session binding was created.
+
+- [ ] **Step 6: Verify Task 4**
+
+Run:
+
+```bash
+cargo +nightly test -Zbuild-dir-new-layout -p lucarne-telegram --quiet
+cargo +nightly test -Zbuild-dir-new-layout -p lucarne-wechat --quiet
+cargo +nightly test -Zbuild-dir-new-layout -p lucarned --quiet
+```
+
+Expected: pass.
+
+- [ ] **Step 7: Commit Task 4**
+
+```bash
+git add crates/lucarne-telegram crates/lucarne-wechat crates/lucarne-adapter crates/lucarned Cargo.lock
+git commit -m "feat: notify chats about updates"
+```
+
+---
+
+### Task 5: Document and verify update awareness end-to-end
+
+**Files:**
+- Modify: `README.md`
+- Modify tests as needed only for deterministic behavior.
+
+- [ ] **Step 1: Document update behavior**
+
+Add README section near install/doctor docs:
+
+```markdown
+### Update checks
+
+`lucarned` checks GitHub Releases once every 24 hours by default. When a newer stable release is available, it sends one Telegram/WeChat notification per version per 24 hours. Lucarne does not auto-update or replace the running daemon.
+
+Disable automatic checks:
+
+```yaml
+updates:
+  enabled: false
+```
+
+Disable chat notifications while keeping checks:
+
+```yaml
+updates:
+  notify: false
+```
+
+Check manually:
+
+```sh
+lucarned update
+```
+
+`lucarned update` prints the latest version, release notes, release URL, and installer/package-manager commands. It does not modify files.
+```
+
+- [ ] **Step 2: Full verification**
+
+Run:
+
+```bash
+cargo +nightly check -Zbuild-dir-new-layout -p lucarned
+cargo +nightly test -Zbuild-dir-new-layout -p lucarned-ctl --features updates
+cargo +nightly test -Zbuild-dir-new-layout -p lucarned-ctl --no-default-features
+cargo +nightly test -Zbuild-dir-new-layout -p lucarne-adapter
+cargo +nightly test -Zbuild-dir-new-layout -p lucarne-telegram
+cargo +nightly test -Zbuild-dir-new-layout -p lucarne-wechat
+git diff --check
+```
+
+Expected: all pass.
+
+- [ ] **Step 3: Manual CLI smoke**
+
+Run against live GitHub if network is available:
+
+```bash
+cargo +nightly run -Zbuild-dir-new-layout -p lucarned -- update
+cargo +nightly run -Zbuild-dir-new-layout -p lucarned -- doctor
+```
+
+Expected:
+- `update` prints current/latest/release/install hint.
+- `doctor` includes `ok: update:` or `warn: update:` but does not fail solely due network.
+
+- [ ] **Step 4: Commit Task 5**
+
+```bash
+git add README.md crates Cargo.lock
+git commit -m "docs: document update awareness"
+```
+
+---
+
+## Self-Review Checklist
+
+- Spec coverage: update checks, opt-out, doctor, update command, notifications, 24h throttle, stable releases only, shared client, no update task, no self-update are covered.
+- No provider/common/history layer changes are required.
+- The only platform-specific installer text is rendered as user-facing update instructions; no OS runtime branching is added to common layers beyond existing CLI display.
+- Plan tasks are sequential because later daemon/adapters depend on core types and parser changes.

--- a/docs/superpowers/specs/2026-05-21-update-awareness-design.md
+++ b/docs/superpowers/specs/2026-05-21-update-awareness-design.md
@@ -1,0 +1,541 @@
+# Update Awareness Design
+
+## Goal
+
+Make Lucarne users aware when a newer GitHub Release is available, without self-updating or replacing a running `lucarned` process.
+
+The feature should:
+
+- check GitHub Releases periodically when the daemon is running,
+- notify users through enabled Telegram and WeChat channels,
+- show update status from `lucarned doctor`,
+- add `lucarned update` as an explicit manual status/help command,
+- let users disable automatic checks in config,
+- remind at most once per version per 24 hours by default,
+- reuse the existing shared HTTP client path,
+- avoid spawning a dedicated update-check task.
+
+This work should be implemented in a separate PR from the Linux/install support chain. The branch can start from `feature/linux-support` while PR #5 is still stacked, then retarget after the base PRs merge.
+
+## Non-goals
+
+This design does not implement automatic binary replacement.
+
+Out of scope:
+
+- downloading and swapping `lucarned`,
+- restarting systemd/LaunchAgent/Task Scheduler services,
+- package-manager mutation,
+- background self-update helpers,
+- GitHub asset signature verification for downloaded binaries,
+- support for prerelease notification,
+- external hosted notification services.
+
+`lucarned update` is intentionally informational. It prints the latest version, changelog summary, release URL, and the installer/package-manager command the user can run manually.
+
+## Default Behavior
+
+Defaults are user-visible and conservative:
+
+```yaml
+updates:
+  enabled: true
+  notify: true
+  check_interval_hours: 24
+  remind_interval_hours: 24
+  repository: tuchg/Lucarne
+```
+
+Semantics:
+
+- `enabled: true` permits daemon automatic checks and `doctor` update checks.
+- `enabled: false` disables daemon automatic checks and `doctor` network checks.
+- `notify: false` allows automatic checks but suppresses chat notifications.
+- `lucarned update` is explicit user intent and performs a manual check even if automatic checks are disabled. Its output should mention when automatic checks are disabled.
+- Only stable GitHub Releases are considered. Drafts and prereleases are ignored.
+- The daemon checks every 24 hours by default.
+- The daemon waits 30-60 seconds after startup before the first automatic check so startup and adapter initialization stay fast.
+- A newer version is notified at most once per version per `remind_interval_hours`, default 24 hours.
+
+Environment overrides should mirror config for operational use:
+
+- `LUCARNED_UPDATES_ENABLED`
+- `LUCARNED_UPDATES_NOTIFY`
+- `LUCARNED_UPDATES_CHECK_INTERVAL_HOURS`
+- `LUCARNED_UPDATES_REMIND_INTERVAL_HOURS`
+- `LUCARNED_UPDATES_REPOSITORY`
+
+Invalid intervals are rejected or clamped to a safe minimum of 1 hour for daemon scheduling. Manual `lucarned update` is not interval-gated.
+
+## Crate Boundaries
+
+### `lucarned-ctl`
+
+Update-checking logic belongs in `lucarned-ctl`, not in `lucarned` main, because `doctor`, `paths`, `autostart`, and the new `update` command are CLI/control-plane concerns already owned by this crate.
+
+`lucarned-ctl` currently has no dependencies. That property should remain true by default. Update support should be feature-gated:
+
+```toml
+[features]
+default = []
+updates = [
+  "dep:reqwest",
+  "dep:serde",
+  "dep:serde_json",
+  "dep:serde_yaml",
+  "dep:tokio",
+  "dep:semver",
+]
+```
+
+`lucarned` enables the feature:
+
+```toml
+lucarned-ctl = { path = "../lucarned-ctl", features = ["updates"] }
+```
+
+The update module layout should stay narrow and testable:
+
+```text
+crates/lucarned-ctl/src/updates/
+  mod.rs          # public facade, config, runtime, status structs
+  github.rs       # GitHub release JSON fetch/parse
+  version.rs      # version normalization and semver comparison
+  state.rs        # last check / last notification persistence
+  render.rs       # doctor, update command, and notification text
+```
+
+`lucarned-ctl` must not depend on Telegram, WeChat, provider, history, or daemon internals.
+
+### `lucarned`
+
+`lucarned` remains the composition root:
+
+- loads config,
+- creates the shared HTTP client,
+- creates the update runtime,
+- drives update checks from the existing daemon main wait loop,
+- forwards update notices to adapters through a generic system-notification bus.
+
+`lucarned` must not own GitHub parsing, version comparison, changelog rendering, or notification throttling.
+
+### `lucarne-adapter`
+
+A generic notification bus belongs in `lucarne-adapter` because enabled adapters receive it through `AdapterContext`.
+
+Proposed shape:
+
+```rust
+#[derive(Debug, Clone)]
+pub enum SystemNotification {
+    UpdateAvailable(SystemUpdateNotification),
+}
+
+#[derive(Debug, Clone)]
+pub struct SystemUpdateNotification {
+    pub current_version: String,
+    pub latest_version: String,
+    pub release_name: String,
+    pub release_url: String,
+    pub published_at: Option<String>,
+    pub body_markdown: String,
+    pub install_hint: String,
+}
+```
+
+The exact type can be adjusted during implementation, but it should contain only channel-agnostic strings and metadata. Platform formatting stays in Telegram and WeChat crates.
+
+`AdapterContext` should expose a cloneable notification source, likely a wrapper around `tokio::sync::broadcast::Sender<SystemNotification>` with a `subscribe()` method. Adapters subscribe when they spawn. The daemon sends notices through the same bus.
+
+### Telegram and WeChat crates
+
+Telegram and WeChat consume generic `SystemNotification` values and render platform-specific messages.
+
+- Telegram sends update notifications to the configured entry chat.
+- WeChat sends update notifications to configured and remembered notification users.
+- Delivery failure is logged and does not fail the daemon.
+- Channel-specific markdown escaping, splitting, rate limits, and recipient lookup stay inside each adapter crate.
+
+Common update code must not know Telegram chat IDs, WeChat user IDs, channel-specific rate limits, or platform markdown rules.
+
+## HTTP Client Ownership
+
+No update-check code creates a new `reqwest::Client` in daemon mode.
+
+The existing shared client helper remains the source of clients:
+
+```rust
+let http_client = lucarne_adapter::default_http_client()?;
+```
+
+Daemon mode:
+
+- `lucarned` creates this client once.
+- The adapter supervisor receives `http_client.clone()`.
+- `UpdateRuntime` receives `http_client.clone()`.
+- `lucarned-ctl::updates` APIs borrow or receive a clone passed by `lucarned`; they never call `reqwest::Client::new()` or `reqwest::Client::builder()`.
+
+CLI mode:
+
+- `lucarned main` creates the same default client for async `doctor` and `update` commands.
+- `lucarned main` passes `&reqwest::Client` into `lucarned-ctl`.
+- `lucarned-ctl` stays client-agnostic.
+
+This keeps proxy/TLS/timeout behavior consistent with existing Telegram/WeChat network code.
+
+## Daemon Runtime Without a Dedicated Task
+
+The update checker should be an independent module, but it should not own a long-lived task.
+
+`lucarned` should drive it from the existing daemon wait loop:
+
+```rust
+let mut updates = updates::UpdateRuntime::new(update_config, update_state, http_client.clone());
+
+loop {
+    tokio::select! {
+        fatal = adapter_supervisor.next_fatal() => {
+            // existing fatal handling
+        }
+        signal = tokio::signal::ctrl_c() => {
+            // existing shutdown handling
+        }
+        notice = updates.next_notice(), if updates.enabled() => {
+            if let Some(notice) = notice {
+                let _ = system_notifications.send(notice.into_system_notification());
+            }
+        }
+    }
+}
+```
+
+`UpdateRuntime::next_notice()` owns scheduling and throttling:
+
+- sleeps until the next due check,
+- performs a timeout-bound GitHub check,
+- compares current and latest versions,
+- consults persisted notification state,
+- records last check and last notification timestamps,
+- returns `Some(UpdateNotice)` only when a chat notification should be sent.
+
+No `tokio::spawn` should be introduced for update checking. The update future is polled by the main daemon loop and dropped naturally on shutdown or fatal error.
+
+Network checks should be bounded so Ctrl-C and adapter-fatal handling are not delayed for long. The check itself should be wrapped in a short timeout, recommended 10 seconds, even though the shared client has a broader default request timeout.
+
+## GitHub Release Check
+
+The checker queries GitHub's latest release endpoint for the configured repository:
+
+```text
+GET https://api.github.com/repos/{owner}/{repo}/releases/latest
+```
+
+Request requirements:
+
+- set a stable `User-Agent`, for example `lucarned/<version>`;
+- set `Accept: application/vnd.github+json`;
+- use the injected shared `reqwest::Client`;
+- treat HTTP non-2xx as a transient warning;
+- cap accepted response size to avoid unexpectedly large memory use.
+
+The parsed fields needed are:
+
+- `tag_name`, e.g. `v0.2.0`,
+- `name`,
+- `html_url`,
+- `body`,
+- `published_at`,
+- `draft`,
+- `prerelease`.
+
+The checker ignores releases where `draft` or `prerelease` is true. The `/latest` endpoint should already do this for normal public releases, but the filter should remain explicit for correctness and tests.
+
+Version comparison:
+
+- current version comes from `env!("CARGO_PKG_VERSION")` in `lucarned-ctl` or is passed in by `lucarned`,
+- latest version is parsed from `tag_name`, with one leading `v` stripped,
+- compare using semver,
+- if latest cannot be parsed, report a warning and do not notify,
+- notify only when `latest > current`,
+- equal or older releases render as current.
+
+## State Persistence
+
+Reminder throttling must survive daemon restart. Use a small state file under the existing lucarned config directory instead of adding a SQLite dependency to `lucarned-ctl`.
+
+Recommended path:
+
+```text
+~/.lucarned/update-state.json
+```
+
+On Windows this follows `paths::default_config_dir()`:
+
+```text
+%LOCALAPPDATA%\lucarned\update-state.json
+```
+
+State shape:
+
+```json
+{
+  "last_checked_at_unix_secs": 1780000000,
+  "last_latest_version": "0.2.0",
+  "last_latest_url": "https://github.com/tuchg/Lucarne/releases/tag/v0.2.0",
+  "last_notified_version": "0.2.0",
+  "last_notified_at_unix_secs": 1780000000
+}
+```
+
+Persistence rules:
+
+- create parent directory if needed,
+- write atomically through a temporary file and rename,
+- ignore unreadable or malformed state with a warning and recreate it,
+- never store secrets,
+- do not fail daemon startup because update state cannot be read or written,
+- if state cannot be written, still allow a notification for the current run but log that throttling may not persist.
+
+Throttling rule:
+
+- If `last_notified_version == latest_version` and `now - last_notified_at < remind_interval`, do not notify.
+- If the version is different, notify immediately after a successful check and persist the new version/time.
+- If `notify: false`, do not write `last_notified_*`; still update `last_checked_*` and `last_latest_*`.
+
+## CLI Behavior
+
+### `lucarned update`
+
+Add a new top-level command:
+
+```text
+lucarned update
+```
+
+Output when current:
+
+```text
+lucarned 0.1.0 is current
+latest: 0.1.0
+release: https://github.com/tuchg/Lucarne/releases/tag/v0.1.0
+```
+
+Output when new version exists:
+
+```text
+current: 0.1.0
+latest: 0.2.0
+release: https://github.com/tuchg/Lucarne/releases/tag/v0.2.0
+
+Changes:
+- ... truncated release notes ...
+
+Update manually:
+  macOS/Linux:
+    curl -fsSL https://github.com/tuchg/Lucarne/releases/latest/download/lucarned-installer.sh | sh
+
+  Windows PowerShell:
+    irm https://github.com/tuchg/Lucarne/releases/latest/download/lucarned-installer.ps1 | iex
+
+If installed through a package manager, use that package manager instead:
+  Homebrew: brew upgrade lucarned
+  AUR: yay -Syu lucarned-bin
+  winget/scoop/choco: use the matching package manager upgrade command
+```
+
+`lucarned update` does not update files. It exits nonzero only for hard local errors such as invalid config path arguments. GitHub/network errors should print a clear error and exit nonzero for manual CLI use.
+
+### `lucarned doctor`
+
+`doctor` appends an update check when automatic checks are enabled.
+
+Possible lines:
+
+```text
+ok: update: checks disabled by config
+ok: update: current version 0.1.0
+warn: update: 0.2.0 available: https://github.com/tuchg/Lucarne/releases/tag/v0.2.0
+warn: update: check failed: GitHub returned 403 rate limited
+```
+
+Network failure in `doctor` should be a warning, not a fatal failure. Optional update-check failure must not make `doctor` exit with failure unless an existing critical check already fails.
+
+If config is missing, default update settings apply and doctor may still check. The existing config-missing warning remains separate.
+
+## Notification Content
+
+Chat notification content should be concise, useful, and bounded.
+
+Recommended generic markdown before channel rendering:
+
+```text
+Lucarne update available: 0.2.0
+
+Current: 0.1.0
+Release: https://github.com/tuchg/Lucarne/releases/tag/v0.2.0
+
+Changes:
+- first release note line
+- second release note line
+
+Manual update:
+macOS/Linux: curl -fsSL https://github.com/tuchg/Lucarne/releases/latest/download/lucarned-installer.sh | sh
+Windows PowerShell: irm https://github.com/tuchg/Lucarne/releases/latest/download/lucarned-installer.ps1 | iex
+
+If installed through a package manager, upgrade with that package manager.
+```
+
+Rendering rules:
+
+- truncate release notes to about 1200 characters before platform-specific escaping,
+- preserve the release URL,
+- include current and latest version,
+- do not include secrets or environment details,
+- avoid mentioning unsupported automatic self-update,
+- set Telegram `silent` to false so users notice the update,
+- let WeChat use its existing notification/rate-limit machinery.
+
+## Adapter Delivery
+
+### Telegram
+
+The Telegram adapter already has a long-lived bot loop and a core-event watcher. Do not add a new update-specific task. Reuse existing loop structure by selecting over a system-notification subscription alongside the current event sources.
+
+Delivery:
+
+- send to the configured entry chat,
+- use the existing `OutgoingMessage::markdown` path,
+- use existing fallback/splitting helpers,
+- log failures without stopping the adapter.
+
+### WeChat
+
+The WeChat service already has a long-lived select loop for incoming messages, core events, pending retries, and rate-limit interactions. Add a system-notification receiver branch to that loop rather than spawning a new task.
+
+Delivery:
+
+- send to `notify_user_ids` plus remembered users, matching existing notification recipient behavior,
+- use existing transport/rate-limit handling,
+- if no known users exist, log and skip,
+- do not bind update notices to provider sessions,
+- do not suppress update notices based on per-workspace direct conversation suppression, because updates are daemon-level notifications rather than agent-session notifications.
+
+## Config Rendering and Init
+
+`lucarned init` should render the `updates` block with defaults so users see the feature and can disable it.
+
+Generated config should include:
+
+```yaml
+updates:
+  enabled: true
+  notify: true
+  check_interval_hours: 24
+  remind_interval_hours: 24
+  repository: tuchg/Lucarne
+```
+
+Existing config parsing should default missing `updates` to enabled. Existing users therefore begin receiving update awareness after upgrading, unless they add:
+
+```yaml
+updates:
+  enabled: false
+```
+
+## Error Handling
+
+Daemon automatic check errors are non-fatal:
+
+- DNS/connect/TLS failure: warn log, no notification.
+- GitHub 403/429 rate limit: warn log, no notification.
+- GitHub 404 repository missing: warn log, no notification.
+- Invalid JSON: warn log, no notification.
+- Invalid semver tag: warn log, no notification.
+- State file read/write failure: warn log; continue.
+- Notification delivery failure: channel-specific warn log; continue.
+
+Manual `lucarned update` should report network and parse errors to stderr and exit nonzero because the user explicitly requested a check.
+
+`doctor` should convert network and parse errors into `warn: update: ...` and keep the existing doctor success/failure policy.
+
+## Privacy and Network Behavior
+
+Automatic checks contact GitHub once per configured interval. The request reveals normal HTTP metadata such as IP address, User-Agent, and target repository. No local config, usernames, agent sessions, chat IDs, or tokens are sent.
+
+Users can disable automatic checks:
+
+```yaml
+updates:
+  enabled: false
+```
+
+Manual `lucarned update` still performs a check because running the command is explicit user intent. The command should mention when automatic checks are disabled to avoid confusion.
+
+## Testing Strategy
+
+### `lucarned-ctl` unit tests
+
+- config defaults enable update checks and notifications,
+- config can disable checks,
+- env overrides config,
+- invalid interval is rejected or clamped consistently,
+- GitHub latest JSON parses required fields,
+- draft and prerelease responses are ignored,
+- semver comparison handles `v0.2.0`, `0.2.0`, equal, older, and invalid tags,
+- changelog truncation keeps release URL and version fields,
+- state file read/write is atomic and tolerant of malformed input,
+- same version inside 24 hours does not notify,
+- same version after 24 hours does notify,
+- new version notifies immediately even if a different version was notified recently,
+- `render_update_cli` prints installer commands without claiming to self-update.
+
+### `lucarned` tests
+
+- `lucarned update` parses as a top-level command,
+- async CLI path passes an injected client to ctl update APIs,
+- daemon constructs one shared client and clones it into adapters and updates,
+- automatic update checks are not started when `updates.enabled=false`,
+- update runtime is driven from the main wait loop without an update-specific spawn.
+
+### Adapter tests
+
+- Telegram receives `SystemNotification::UpdateAvailable` and sends one message to entry chat,
+- Telegram uses existing markdown/fallback path,
+- WeChat sends update notices to configured/known notification users,
+- WeChat skips cleanly when no notification users exist,
+- adapter notification failures do not become fatal adapter errors.
+
+### Integration and verification
+
+Run existing verification commands after implementation:
+
+```sh
+cargo +nightly check -Zbuild-dir-new-layout -p lucarned
+cargo +nightly test -Zbuild-dir-new-layout -p lucarned-ctl
+cargo +nightly test -Zbuild-dir-new-layout -p lucarne-telegram
+cargo +nightly test -Zbuild-dir-new-layout -p lucarne-wechat
+```
+
+Release smoke should verify:
+
+```sh
+lucarned --version
+lucarned update
+lucarned doctor
+```
+
+Network-dependent tests should use mocked HTTP responses or local test servers. They should not depend on live GitHub availability in normal CI.
+
+## Acceptance Criteria
+
+- `lucarned update` reports latest release information and manual update commands.
+- `lucarned doctor` reports update status without making network failure fatal.
+- daemon automatic checks are enabled by default and configurable off.
+- daemon checks stable GitHub Releases every 24 hours by default.
+- daemon sends at most one notification per version per 24 hours by default.
+- daemon does not spawn a dedicated update task.
+- update checks use the existing `lucarne_adapter::default_http_client()` client supplied by `lucarned`.
+- `lucarned-ctl` stays dependency-free without the `updates` feature.
+- provider/common/history layers do not gain Telegram, WeChat, GitHub, or OS-specific update branching.
+- Telegram and WeChat notification routing remains adapter-owned.
+- no automatic binary replacement or service restart is introduced.


### PR DESCRIPTION
## Summary
- Add feature-gated update checking core in `lucarned-ctl` plus `lucarned update` and update-aware `doctor`.
- Drive daemon release checks from the existing main loop without an update-specific task, using the shared HTTP client.
- Notify enabled Telegram/WeChat channels about newer stable GitHub Releases with per-version 24h throttling.

## Test Plan
- [x] `cargo +nightly check -Zbuild-dir-new-layout -p lucarned`
- [x] `cargo +nightly test -Zbuild-dir-new-layout -p lucarned-ctl --features updates`
- [x] `cargo +nightly test -Zbuild-dir-new-layout -p lucarned-ctl --no-default-features`
- [x] `cargo +nightly test -Zbuild-dir-new-layout -p lucarne-adapter`
- [x] `cargo +nightly test -Zbuild-dir-new-layout -p lucarne-telegram`
- [x] `cargo +nightly test -Zbuild-dir-new-layout -p lucarne-wechat`
- [x] `git diff --check`
- [x] `cargo +nightly run -Zbuild-dir-new-layout -p lucarned -- update`
- [x] `cargo +nightly run -Zbuild-dir-new-layout -p lucarned -- doctor`

## Notes
- This PR is intentionally stacked on `feature/linux-support` so it stays independent from the Linux support PR while reusing its install/autostart work.
- No automatic self-update or running binary replacement is implemented.