### PR TITLE
feat: add windows/linux support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,9 +148,12 @@ jobs:
           APT_LISTCHANGES_FRONTEND: none
         run: |
           ${{ matrix.packages_install }}
-      - name: Use clang backend for Windows ARM64 cross build
+      - name: Prepare Windows ARM64 clang sysroot
         if: ${{ contains(matrix.targets, 'aarch64-pc-windows-msvc') }}
-        run: echo "XWIN_CROSS_COMPILER=clang" >> "$GITHUB_ENV"
+        run: |
+          echo "XWIN_CROSS_COMPILER=clang" >> "$GITHUB_ENV"
+          cargo xwin cache windows-msvc-sysroot
+          find "$HOME/.cache/cargo-xwin/windows-msvc-sysroot" -type f -name windows.h -exec sh -c 'for path do dir=$(dirname "$path"); ln -sf windows.h "$dir/Windows.h"; done' sh {} +
       - name: Build artifacts
         run: |
           # Actually do builds and make zips and whatnot

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,6 +148,9 @@ jobs:
           APT_LISTCHANGES_FRONTEND: none
         run: |
           ${{ matrix.packages_install }}
+      - name: Use clang backend for Windows ARM64 cross build
+        if: ${{ contains(matrix.targets, 'aarch64-pc-windows-msvc') }}
+        run: echo "XWIN_CROSS_COMPILER=clang" >> "$GITHUB_ENV"
       - name: Build artifacts
         run: |
           # Actually do builds and make zips and whatnot

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -281,26 +281,143 @@ jobs:
         run: |
           # Remove the granular manifests
           rm -f artifacts/*-dist-manifest.json
+      - name: Version archive asset names
+        env:
+          TAG: ${{ needs.plan.outputs.tag }}
+        run: |
+          set -euo pipefail
+          cd artifacts
+          targets=(
+            aarch64-apple-darwin
+            x86_64-apple-darwin
+            aarch64-pc-windows-msvc
+            x86_64-pc-windows-msvc
+            aarch64-unknown-linux-gnu
+            x86_64-unknown-linux-gnu
+          )
+          for target in "${targets[@]}"; do
+            old="lucarned-${target}.tar.xz"
+            new="lucarned-${TAG}-${target}.tar.xz"
+            if [[ ! -f "$old" ]]; then
+              echo "missing archive: $old" >&2
+              exit 1
+            fi
+            mv "$old" "$new"
+            sha256sum "$new" | sed 's/  / */' > "$new.sha256"
+            rm -f "$old.sha256"
+          done
+          sha256sum lucarned-"$TAG"-*.tar.xz source.tar.gz | sed 's/  / */' | sort -k2 > sha256.sum
+          python3 - <<'PY'
+          import os
+          from pathlib import Path
+
+          tag = os.environ["TAG"]
+          targets = [
+              "aarch64-apple-darwin",
+              "x86_64-apple-darwin",
+              "aarch64-pc-windows-msvc",
+              "x86_64-pc-windows-msvc",
+              "aarch64-unknown-linux-gnu",
+              "x86_64-unknown-linux-gnu",
+          ]
+          for name in ["lucarned-installer.sh", "lucarned-installer.ps1", "dist-manifest.json"]:
+              path = Path(name)
+              if not path.exists():
+                  continue
+              text = path.read_text(encoding="utf-8")
+              for target in targets:
+                  text = text.replace(
+                      f"lucarned-{target}.tar.xz",
+                      f"lucarned-{tag}-{target}.tar.xz",
+                  )
+              path.write_text(text, encoding="utf-8")
+          PY
       - name: Create GitHub Release
         env:
           PRERELEASE_FLAG: "${{ fromJson(steps.host.outputs.manifest).announcement_is_prerelease && '--prerelease' || '' }}"
           ANNOUNCEMENT_TITLE: "${{ fromJson(steps.host.outputs.manifest).announcement_title }}"
           ANNOUNCEMENT_BODY: "${{ fromJson(steps.host.outputs.manifest).announcement_github_body }}"
           RELEASE_COMMIT: "${{ github.sha }}"
+          TAG: ${{ needs.plan.outputs.tag }}
         run: |
           # Write and read notes from a file to avoid quoting breaking things
           echo "$ANNOUNCEMENT_BODY" > $RUNNER_TEMP/notes.txt
+          python3 - <<'PY'
+          import os
+          from pathlib import Path
+
+          path = Path(os.environ["RUNNER_TEMP"]) / "notes.txt"
+          tag = os.environ["TAG"]
+          targets = [
+              "aarch64-apple-darwin",
+              "x86_64-apple-darwin",
+              "aarch64-pc-windows-msvc",
+              "x86_64-pc-windows-msvc",
+              "aarch64-unknown-linux-gnu",
+              "x86_64-unknown-linux-gnu",
+          ]
+          text = path.read_text(encoding="utf-8")
+          for target in targets:
+              text = text.replace(
+                  f"lucarned-{target}.tar.xz",
+                  f"lucarned-{tag}-{target}.tar.xz",
+              )
+          path.write_text(text, encoding="utf-8")
+          PY
 
           gh release create "${{ needs.plan.outputs.tag }}" --target "$RELEASE_COMMIT" $PRERELEASE_FLAG --title "$ANNOUNCEMENT_TITLE" --notes-file "$RUNNER_TEMP/notes.txt" artifacts/*
+
+  update-formula:
+    needs:
+      - plan
+      - host
+    if: ${{ always() && needs.host.result == 'success' && needs.plan.outputs.publishing == 'true' && !fromJson(needs.host.outputs.val).announcement_is_prerelease }}
+    runs-on: "ubuntu-22.04"
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: main
+      - name: Fetch release checksums
+        env:
+          TAG: ${{ needs.plan.outputs.tag }}
+        run: |
+          gh release download "$TAG" --pattern "lucarned-${TAG}-aarch64-apple-darwin.tar.xz.sha256" --pattern "lucarned-${TAG}-x86_64-apple-darwin.tar.xz.sha256"
+      - name: Generate formula
+        env:
+          TAG: ${{ needs.plan.outputs.tag }}
+        run: |
+          version="${TAG#v}"
+          arm64_sha="$(awk '{ print $1; exit }' "lucarned-${TAG}-aarch64-apple-darwin.tar.xz.sha256")"
+          x86_64_sha="$(awk '{ print $1; exit }' "lucarned-${TAG}-x86_64-apple-darwin.tar.xz.sha256")"
+          python3 scripts/release/update-homebrew-formula.py Formula/lucarned.rb --version "$version" --arm64-sha "$arm64_sha" --x86-64-sha "$x86_64_sha"
+      - name: Validate formula syntax
+        run: ruby -c Formula/lucarned.rb
+      - name: Commit and push formula
+        env:
+          TAG: ${{ needs.plan.outputs.tag }}
+        run: |
+          if git diff --quiet -- Formula/lucarned.rb; then
+            echo "Formula already up to date"
+            exit 0
+          fi
+          version="${TAG#v}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add Formula/lucarned.rb
+          git commit -m "brew: update lucarned v$version"
+          git push origin HEAD:main
 
   announce:
     needs:
       - plan
       - host
+      - update-formula
     # use "always() && ..." to allow us to wait for all publish jobs while
     # still allowing individual publish jobs to skip themselves (for prereleases).
     # "host" however must run to completion, no skipping allowed!
-    if: ${{ always() && needs.host.result == 'success' }}
+    if: ${{ always() && needs.host.result == 'success' && (needs.update-formula.result == 'success' || needs.update-formula.result == 'skipped') }}
     runs-on: "ubuntu-22.04"
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,6 +129,12 @@ jobs:
           fi
       - name: Install dist
         run: ${{ matrix.install_dist.run }}
+      - name: Configure noninteractive apt
+        if: ${{ matrix.container }}
+        run: |
+          if command -v apt-get > /dev/null 2>&1; then
+            echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/90assumeyes
+          fi
       # Get the dist-manifest
       - name: Fetch local artifacts
         uses: actions/download-artifact@v7
@@ -137,6 +143,9 @@ jobs:
           path: target/distrib/
           merge-multiple: true
       - name: Install dependencies
+        env:
+          DEBIAN_FRONTEND: noninteractive
+          APT_LISTCHANGES_FRONTEND: none
         run: |
           ${{ matrix.packages_install }}
       - name: Build artifacts

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,7 +15,7 @@ dependencies = [
 
 [[package]]
 name = "agent-sessions"
-version = "0.3.0-rc.5"
+version = "0.3.0"
 dependencies = [
  "bytes",
  "criterion",
@@ -1337,7 +1337,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lucarne"
-version = "0.3.0-rc.5"
+version = "0.3.0"
 dependencies = [
  "agent-sessions",
  "async-trait",
@@ -1362,7 +1362,7 @@ dependencies = [
 
 [[package]]
 name = "lucarne-adapter"
-version = "0.3.0-rc.5"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "lucarne",
@@ -1376,7 +1376,7 @@ dependencies = [
 
 [[package]]
 name = "lucarne-channel"
-version = "0.3.0-rc.5"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1389,7 +1389,7 @@ dependencies = [
 
 [[package]]
 name = "lucarne-fakeagent"
-version = "0.3.0-rc.5"
+version = "0.3.0"
 dependencies = [
  "nix",
  "windows-sys 0.61.2",
@@ -1397,7 +1397,7 @@ dependencies = [
 
 [[package]]
 name = "lucarne-telegram"
-version = "0.3.0-rc.5"
+version = "0.3.0"
 dependencies = [
  "agent-sessions",
  "async-trait",
@@ -1421,7 +1421,7 @@ dependencies = [
 
 [[package]]
 name = "lucarne-wechat"
-version = "0.3.0-rc.5"
+version = "0.3.0"
 dependencies = [
  "agent-sessions",
  "async-trait",
@@ -1445,7 +1445,7 @@ dependencies = [
 
 [[package]]
 name = "lucarned"
-version = "0.3.0-rc.5"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "dotenvy",
@@ -1467,7 +1467,7 @@ dependencies = [
 
 [[package]]
 name = "lucarned-ctl"
-version = "0.3.0-rc.5"
+version = "0.3.0"
 dependencies = [
  "reqwest",
  "semver",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,7 +15,7 @@ dependencies = [
 
 [[package]]
 name = "agent-sessions"
-version = "0.3.0-rc.4"
+version = "0.3.0-rc.5"
 dependencies = [
  "bytes",
  "criterion",
@@ -1337,7 +1337,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lucarne"
-version = "0.3.0-rc.4"
+version = "0.3.0-rc.5"
 dependencies = [
  "agent-sessions",
  "async-trait",
@@ -1362,7 +1362,7 @@ dependencies = [
 
 [[package]]
 name = "lucarne-adapter"
-version = "0.3.0-rc.4"
+version = "0.3.0-rc.5"
 dependencies = [
  "async-trait",
  "lucarne",
@@ -1376,7 +1376,7 @@ dependencies = [
 
 [[package]]
 name = "lucarne-channel"
-version = "0.3.0-rc.4"
+version = "0.3.0-rc.5"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1389,7 +1389,7 @@ dependencies = [
 
 [[package]]
 name = "lucarne-fakeagent"
-version = "0.3.0-rc.4"
+version = "0.3.0-rc.5"
 dependencies = [
  "nix",
  "windows-sys 0.61.2",
@@ -1397,7 +1397,7 @@ dependencies = [
 
 [[package]]
 name = "lucarne-telegram"
-version = "0.3.0-rc.4"
+version = "0.3.0-rc.5"
 dependencies = [
  "agent-sessions",
  "async-trait",
@@ -1421,7 +1421,7 @@ dependencies = [
 
 [[package]]
 name = "lucarne-wechat"
-version = "0.3.0-rc.4"
+version = "0.3.0-rc.5"
 dependencies = [
  "agent-sessions",
  "async-trait",
@@ -1445,7 +1445,7 @@ dependencies = [
 
 [[package]]
 name = "lucarned"
-version = "0.3.0-rc.4"
+version = "0.3.0-rc.5"
 dependencies = [
  "async-trait",
  "dotenvy",
@@ -1467,7 +1467,7 @@ dependencies = [
 
 [[package]]
 name = "lucarned-ctl"
-version = "0.3.0-rc.4"
+version = "0.3.0-rc.5"
 dependencies = [
  "reqwest",
  "semver",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,7 +15,7 @@ dependencies = [
 
 [[package]]
 name = "agent-sessions"
-version = "0.3.0-rc.1"
+version = "0.3.0-rc.2"
 dependencies = [
  "bytes",
  "criterion",
@@ -1337,7 +1337,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lucarne"
-version = "0.3.0-rc.1"
+version = "0.3.0-rc.2"
 dependencies = [
  "agent-sessions",
  "async-trait",
@@ -1362,7 +1362,7 @@ dependencies = [
 
 [[package]]
 name = "lucarne-adapter"
-version = "0.3.0-rc.1"
+version = "0.3.0-rc.2"
 dependencies = [
  "async-trait",
  "lucarne",
@@ -1376,7 +1376,7 @@ dependencies = [
 
 [[package]]
 name = "lucarne-channel"
-version = "0.3.0-rc.1"
+version = "0.3.0-rc.2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1389,7 +1389,7 @@ dependencies = [
 
 [[package]]
 name = "lucarne-fakeagent"
-version = "0.3.0-rc.1"
+version = "0.3.0-rc.2"
 dependencies = [
  "nix",
  "windows-sys 0.61.2",
@@ -1397,7 +1397,7 @@ dependencies = [
 
 [[package]]
 name = "lucarne-telegram"
-version = "0.3.0-rc.1"
+version = "0.3.0-rc.2"
 dependencies = [
  "agent-sessions",
  "async-trait",
@@ -1421,7 +1421,7 @@ dependencies = [
 
 [[package]]
 name = "lucarne-wechat"
-version = "0.3.0-rc.1"
+version = "0.3.0-rc.2"
 dependencies = [
  "agent-sessions",
  "async-trait",
@@ -1445,7 +1445,7 @@ dependencies = [
 
 [[package]]
 name = "lucarned"
-version = "0.3.0-rc.1"
+version = "0.3.0-rc.2"
 dependencies = [
  "async-trait",
  "dotenvy",
@@ -1467,7 +1467,7 @@ dependencies = [
 
 [[package]]
 name = "lucarned-ctl"
-version = "0.3.0-rc.1"
+version = "0.3.0-rc.2"
 dependencies = [
  "reqwest",
  "semver",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,7 +15,7 @@ dependencies = [
 
 [[package]]
 name = "agent-sessions"
-version = "0.2.3"
+version = "0.3.0-rc.1"
 dependencies = [
  "bytes",
  "criterion",
@@ -1337,7 +1337,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lucarne"
-version = "0.2.3"
+version = "0.3.0-rc.1"
 dependencies = [
  "agent-sessions",
  "async-trait",
@@ -1362,7 +1362,7 @@ dependencies = [
 
 [[package]]
 name = "lucarne-adapter"
-version = "0.2.3"
+version = "0.3.0-rc.1"
 dependencies = [
  "async-trait",
  "lucarne",
@@ -1376,7 +1376,7 @@ dependencies = [
 
 [[package]]
 name = "lucarne-channel"
-version = "0.2.3"
+version = "0.3.0-rc.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1389,7 +1389,7 @@ dependencies = [
 
 [[package]]
 name = "lucarne-fakeagent"
-version = "0.2.3"
+version = "0.3.0-rc.1"
 dependencies = [
  "nix",
  "windows-sys 0.61.2",
@@ -1397,7 +1397,7 @@ dependencies = [
 
 [[package]]
 name = "lucarne-telegram"
-version = "0.2.3"
+version = "0.3.0-rc.1"
 dependencies = [
  "agent-sessions",
  "async-trait",
@@ -1421,7 +1421,7 @@ dependencies = [
 
 [[package]]
 name = "lucarne-wechat"
-version = "0.2.3"
+version = "0.3.0-rc.1"
 dependencies = [
  "agent-sessions",
  "async-trait",
@@ -1445,7 +1445,7 @@ dependencies = [
 
 [[package]]
 name = "lucarned"
-version = "0.2.3"
+version = "0.3.0-rc.1"
 dependencies = [
  "async-trait",
  "dotenvy",
@@ -1467,7 +1467,7 @@ dependencies = [
 
 [[package]]
 name = "lucarned-ctl"
-version = "0.2.3"
+version = "0.3.0-rc.1"
 dependencies = [
  "reqwest",
  "semver",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,7 +15,7 @@ dependencies = [
 
 [[package]]
 name = "agent-sessions"
-version = "0.3.0-rc.2"
+version = "0.3.0-rc.3"
 dependencies = [
  "bytes",
  "criterion",
@@ -1337,7 +1337,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lucarne"
-version = "0.3.0-rc.2"
+version = "0.3.0-rc.3"
 dependencies = [
  "agent-sessions",
  "async-trait",
@@ -1362,7 +1362,7 @@ dependencies = [
 
 [[package]]
 name = "lucarne-adapter"
-version = "0.3.0-rc.2"
+version = "0.3.0-rc.3"
 dependencies = [
  "async-trait",
  "lucarne",
@@ -1376,7 +1376,7 @@ dependencies = [
 
 [[package]]
 name = "lucarne-channel"
-version = "0.3.0-rc.2"
+version = "0.3.0-rc.3"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1389,7 +1389,7 @@ dependencies = [
 
 [[package]]
 name = "lucarne-fakeagent"
-version = "0.3.0-rc.2"
+version = "0.3.0-rc.3"
 dependencies = [
  "nix",
  "windows-sys 0.61.2",
@@ -1397,7 +1397,7 @@ dependencies = [
 
 [[package]]
 name = "lucarne-telegram"
-version = "0.3.0-rc.2"
+version = "0.3.0-rc.3"
 dependencies = [
  "agent-sessions",
  "async-trait",
@@ -1421,7 +1421,7 @@ dependencies = [
 
 [[package]]
 name = "lucarne-wechat"
-version = "0.3.0-rc.2"
+version = "0.3.0-rc.3"
 dependencies = [
  "agent-sessions",
  "async-trait",
@@ -1445,7 +1445,7 @@ dependencies = [
 
 [[package]]
 name = "lucarned"
-version = "0.3.0-rc.2"
+version = "0.3.0-rc.3"
 dependencies = [
  "async-trait",
  "dotenvy",
@@ -1467,7 +1467,7 @@ dependencies = [
 
 [[package]]
 name = "lucarned-ctl"
-version = "0.3.0-rc.2"
+version = "0.3.0-rc.3"
 dependencies = [
  "reqwest",
  "semver",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,7 +15,7 @@ dependencies = [
 
 [[package]]
 name = "agent-sessions"
-version = "0.3.0-rc.3"
+version = "0.3.0-rc.4"
 dependencies = [
  "bytes",
  "criterion",
@@ -1337,7 +1337,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lucarne"
-version = "0.3.0-rc.3"
+version = "0.3.0-rc.4"
 dependencies = [
  "agent-sessions",
  "async-trait",
@@ -1362,7 +1362,7 @@ dependencies = [
 
 [[package]]
 name = "lucarne-adapter"
-version = "0.3.0-rc.3"
+version = "0.3.0-rc.4"
 dependencies = [
  "async-trait",
  "lucarne",
@@ -1376,7 +1376,7 @@ dependencies = [
 
 [[package]]
 name = "lucarne-channel"
-version = "0.3.0-rc.3"
+version = "0.3.0-rc.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1389,7 +1389,7 @@ dependencies = [
 
 [[package]]
 name = "lucarne-fakeagent"
-version = "0.3.0-rc.3"
+version = "0.3.0-rc.4"
 dependencies = [
  "nix",
  "windows-sys 0.61.2",
@@ -1397,7 +1397,7 @@ dependencies = [
 
 [[package]]
 name = "lucarne-telegram"
-version = "0.3.0-rc.3"
+version = "0.3.0-rc.4"
 dependencies = [
  "agent-sessions",
  "async-trait",
@@ -1421,7 +1421,7 @@ dependencies = [
 
 [[package]]
 name = "lucarne-wechat"
-version = "0.3.0-rc.3"
+version = "0.3.0-rc.4"
 dependencies = [
  "agent-sessions",
  "async-trait",
@@ -1445,7 +1445,7 @@ dependencies = [
 
 [[package]]
 name = "lucarned"
-version = "0.3.0-rc.3"
+version = "0.3.0-rc.4"
 dependencies = [
  "async-trait",
  "dotenvy",
@@ -1467,7 +1467,7 @@ dependencies = [
 
 [[package]]
 name = "lucarned-ctl"
-version = "0.3.0-rc.3"
+version = "0.3.0-rc.4"
 dependencies = [
  "reqwest",
  "semver",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.0-rc.3"
+version = "0.3.0-rc.4"
 edition = "2021"
 license = "MIT"
 rust-version = "1.75"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.3"
+version = "0.3.0-rc.1"
 edition = "2021"
 license = "MIT"
 rust-version = "1.75"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.0-rc.5"
+version = "0.3.0"
 edition = "2021"
 license = "MIT"
 rust-version = "1.75"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.0-rc.2"
+version = "0.3.0-rc.3"
 edition = "2021"
 license = "MIT"
 rust-version = "1.75"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.0-rc.1"
+version = "0.3.0-rc.2"
 edition = "2021"
 license = "MIT"
 rust-version = "1.75"
@@ -72,6 +72,7 @@ panic = "unwind"
 
 [workspace.metadata.dist]
 cargo-dist-version = "0.31.0"
+allow-dirty = ["ci"]
 ci = ["github"]
 installers = ["shell", "powershell"]
 targets = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.0-rc.4"
+version = "0.3.0-rc.5"
 edition = "2021"
 license = "MIT"
 rust-version = "1.75"

--- a/README.cn.md
+++ b/README.cn.md
@@ -22,14 +22,33 @@
 
 ---
 
-## 快速启动（Homebrew）
+## 快速启动
 
 ### 1. 安装
+
+macOS / Linux：
+
+```bash
+curl -LsSf https://github.com/tuchg/Lucarne/releases/latest/download/lucarned-installer.sh | sh
+```
+
+Windows PowerShell：
+
+```powershell
+powershell -c "irm https://github.com/tuchg/Lucarne/releases/latest/download/lucarned-installer.ps1 | iex"
+```
+
+<details>
+<summary>Homebrew</summary>
 
 ```bash
 brew tap tuchg/Lucarne https://github.com/tuchg/Lucarne
 brew install lucarned
 ```
+
+也可以在 GitHub Releases 下载 macOS、Linux、Windows 的 x86_64 / aarch64 发布包。
+
+</details>
 
 ### 2. 初始化
 
@@ -46,9 +65,40 @@ lucarned init
 
 ### 3. 启动后台服务
 
+Homebrew：
+
 ```bash
 brew services start lucarned
 ```
+
+其他安装方式：
+
+```bash
+lucarned autostart install --start
+```
+
+<details>
+<summary>平台说明</summary>
+
+`lucarned autostart` 使用各系统的用户级服务管理器：
+
+- macOS：LaunchAgent
+- Windows：Task Scheduler 登录任务
+- Linux：systemd user service
+
+Linux autostart 需要 systemd user service。非 systemd Linux 可以手动运行 `lucarned`。
+
+常用诊断命令：
+
+```bash
+lucarned doctor
+lucarned paths
+lucarned autostart status
+lucarned autostart start
+lucarned autostart stop
+```
+
+</details>
 
 ### 4. 打开 Telegram 面板 （可选）
 
@@ -63,12 +113,13 @@ brew services start lucarned
 ```bash
 brew services restart lucarned
 brew services stop lucarned
+lucarned update
 ```
 
 ```text
-配置: ~/.lucarned/lucarned.yaml
-状态: ~/.lucarned/state.sqlite3
-日志: ~/.lucarned/logs/lucarned.YYYY-MM-DD.log
+macOS/Linux 配置: ~/.lucarned/lucarned.yaml
+Windows 配置:     %LOCALAPPDATA%\lucarned\lucarned.yaml
+日志:             lucarned paths
 ```
 
 ---
@@ -165,8 +216,8 @@ cargo +nightly test -Zbuild-dir-new-layout
 ---
 
 ## Roadmap
-- [ ] Linux 支持：补齐安装说明、服务管理、发布包与 smoke test
-- [ ] Windows 支持：补齐安装说明、后台运行、路径 / 进程兼容与发布包
+- [x] Linux 支持：补齐安装说明、服务管理、发布包与 smoke test
+- [x] Windows 支持：补齐安装说明、后台运行、路径 / 进程兼容与发布包
 - [ ] 消息模式 steer/queue
 - [ ] agent-sessions 整理为独立crate
 - [ ] 支持远程 agent 环境

--- a/README.cn.md
+++ b/README.cn.md
@@ -26,6 +26,8 @@
 
 ### 1. 安装
 
+推荐一键脚本：
+
 macOS / Linux：
 
 ```bash
@@ -39,7 +41,9 @@ powershell -c "irm https://github.com/tuchg/Lucarne/releases/latest/download/luc
 ```
 
 <details>
-<summary>Homebrew</summary>
+<summary>Homebrew 与发布包</summary>
+
+Homebrew：
 
 ```bash
 brew tap tuchg/Lucarne https://github.com/tuchg/Lucarne
@@ -65,17 +69,22 @@ lucarned init
 
 ### 3. 启动后台服务
 
-Homebrew：
-
-```bash
-brew services start lucarned
-```
-
-其他安装方式：
+推荐一键 autostart：
 
 ```bash
 lucarned autostart install --start
 ```
+
+<details>
+<summary>Homebrew service 可选命令</summary>
+
+```bash
+brew services start lucarned
+brew services restart lucarned
+brew services stop lucarned
+```
+
+</details>
 
 <details>
 <summary>平台说明</summary>
@@ -87,16 +96,6 @@ lucarned autostart install --start
 - Linux：systemd user service
 
 Linux autostart 需要 systemd user service。非 systemd Linux 可以手动运行 `lucarned`。
-
-常用诊断命令：
-
-```bash
-lucarned doctor
-lucarned paths
-lucarned autostart status
-lucarned autostart start
-lucarned autostart stop
-```
 
 </details>
 
@@ -111,8 +110,11 @@ lucarned autostart stop
 ### 常用命令
 
 ```bash
-brew services restart lucarned
-brew services stop lucarned
+lucarned doctor
+lucarned paths
+lucarned autostart status
+lucarned autostart start
+lucarned autostart stop
 lucarned update
 ```
 
@@ -221,6 +223,7 @@ cargo +nightly test -Zbuild-dir-new-layout
 - [ ] 消息模式 steer/queue
 - [ ] agent-sessions 整理为独立crate
 - [ ] 支持远程 agent 环境
+- [ ] 更多 Agent Provider：Cursor、opencode 等
 - [ ] More channels：Discord、Slack、飞书、钉钉、Matrix、QQ 等更多入口
 - [ ] ....
 

--- a/README.cn.md
+++ b/README.cn.md
@@ -118,6 +118,14 @@ lucarned autostart stop
 lucarned update
 ```
 
+Homebrew service 命令：
+
+```bash
+brew services start lucarned
+brew services restart lucarned
+brew services stop lucarned
+```
+
 ```text
 macOS/Linux 配置: ~/.lucarned/lucarned.yaml
 Windows 配置:     %LOCALAPPDATA%\lucarned\lucarned.yaml

--- a/README.cn.md
+++ b/README.cn.md
@@ -118,13 +118,16 @@ lucarned autostart stop
 lucarned update
 ```
 
-Homebrew service 命令：
+<details>
+<summary>Homebrew service 命令</summary>
 
 ```bash
 brew services start lucarned
 brew services restart lucarned
 brew services stop lucarned
 ```
+
+</details>
 
 ```text
 macOS/Linux 配置: ~/.lucarned/lucarned.yaml

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ English | [中文](README.cn.md)
 
 ### 1. Install
 
+Recommended one-line installers:
+
 macOS / Linux:
 
 ```bash
@@ -67,17 +69,22 @@ Initialization guides you through:
 
 ### 3. Start the background service
 
-Homebrew:
-
-```bash
-brew services start lucarned
-```
-
-Other installs:
+Recommended one-command autostart:
 
 ```bash
 lucarned autostart install --start
 ```
+
+<details>
+<summary>Homebrew service alternative</summary>
+
+```bash
+brew services start lucarned
+brew services restart lucarned
+brew services stop lucarned
+```
+
+</details>
 
 <details>
 <summary>Platform notes</summary>
@@ -89,16 +96,6 @@ lucarned autostart install --start
 - Linux: systemd user service
 
 Linux autostart requires systemd user services. Non-systemd Linux can run `lucarned` manually.
-
-Useful commands:
-
-```bash
-lucarned doctor
-lucarned paths
-lucarned autostart status
-lucarned autostart start
-lucarned autostart stop
-```
 
 </details>
 
@@ -113,8 +110,11 @@ After the Lucarne panel appears, you can create workspaces, bind agents, resume 
 ### Common commands
 
 ```bash
-brew services restart lucarned
-brew services stop lucarned
+lucarned doctor
+lucarned paths
+lucarned autostart status
+lucarned autostart start
+lucarned autostart stop
 lucarned update
 ```
 
@@ -223,6 +223,7 @@ cargo +nightly test -Zbuild-dir-new-layout
 - [ ] Message modes: steer / queue
 - [ ] Split `agent-sessions` into an independent crate
 - [ ] Support remote agent environments
+- [ ] More agent providers: Cursor, opencode, and more
 - [ ] More channels: Discord, Slack, Feishu, DingTalk, Matrix, QQ, and more
 - [ ] ....
 

--- a/README.md
+++ b/README.md
@@ -118,13 +118,16 @@ lucarned autostart stop
 lucarned update
 ```
 
-Homebrew service commands:
+<details>
+<summary>Homebrew service commands</summary>
 
 ```bash
 brew services start lucarned
 brew services restart lucarned
 brew services stop lucarned
 ```
+
+</details>
 
 ```text
 macOS/Linux config: ~/.lucarned/lucarned.yaml

--- a/README.md
+++ b/README.md
@@ -22,14 +22,35 @@ English | [中文](README.cn.md)
 
 ---
 
-## Quick Start (Homebrew)
+## Quick Start
 
 ### 1. Install
+
+macOS / Linux:
+
+```bash
+curl -LsSf https://github.com/tuchg/Lucarne/releases/latest/download/lucarned-installer.sh | sh
+```
+
+Windows PowerShell:
+
+```powershell
+powershell -c "irm https://github.com/tuchg/Lucarne/releases/latest/download/lucarned-installer.ps1 | iex"
+```
+
+<details>
+<summary>Homebrew and release archives</summary>
+
+Homebrew:
 
 ```bash
 brew tap tuchg/Lucarne https://github.com/tuchg/Lucarne
 brew install lucarned
 ```
+
+Release archives are also available for macOS, Linux, and Windows on x86_64 and aarch64.
+
+</details>
 
 ### 2. Initialize
 
@@ -46,9 +67,40 @@ Initialization guides you through:
 
 ### 3. Start the background service
 
+Homebrew:
+
 ```bash
 brew services start lucarned
 ```
+
+Other installs:
+
+```bash
+lucarned autostart install --start
+```
+
+<details>
+<summary>Platform notes</summary>
+
+`lucarned autostart` uses native user-level service managers:
+
+- macOS: LaunchAgent
+- Windows: Task Scheduler logon task
+- Linux: systemd user service
+
+Linux autostart requires systemd user services. Non-systemd Linux can run `lucarned` manually.
+
+Useful commands:
+
+```bash
+lucarned doctor
+lucarned paths
+lucarned autostart status
+lucarned autostart start
+lucarned autostart stop
+```
+
+</details>
 
 ### 4. Open the Telegram panel (optional)
 
@@ -63,12 +115,13 @@ After the Lucarne panel appears, you can create workspaces, bind agents, resume 
 ```bash
 brew services restart lucarned
 brew services stop lucarned
+lucarned update
 ```
 
 ```text
-Config: ~/.lucarned/lucarned.yaml
-State:  ~/.lucarned/state.sqlite3
-Logs:   ~/.lucarned/logs/lucarned.YYYY-MM-DD.log
+macOS/Linux config: ~/.lucarned/lucarned.yaml
+Windows config:     %LOCALAPPDATA%\lucarned\lucarned.yaml
+Logs:               lucarned paths
 ```
 
 ---
@@ -165,8 +218,8 @@ cargo +nightly test -Zbuild-dir-new-layout
 ---
 
 ## Roadmap
-- [ ] Linux support: installation docs, service management, release packages, and smoke tests
-- [ ] Windows support: installation docs, background execution, path / process compatibility, and release packages
+- [x] Linux support: installation docs, service management, release packages, and smoke tests
+- [x] Windows support: installation docs, background execution, path / process compatibility, and release packages
 - [ ] Message modes: steer / queue
 - [ ] Split `agent-sessions` into an independent crate
 - [ ] Support remote agent environments

--- a/README.md
+++ b/README.md
@@ -118,6 +118,14 @@ lucarned autostart stop
 lucarned update
 ```
 
+Homebrew service commands:
+
+```bash
+brew services start lucarned
+brew services restart lucarned
+brew services stop lucarned
+```
+
 ```text
 macOS/Linux config: ~/.lucarned/lucarned.yaml
 Windows config:     %LOCALAPPDATA%\lucarned\lucarned.yaml

--- a/scripts/release/test_update_homebrew_formula.py
+++ b/scripts/release/test_update_homebrew_formula.py
@@ -57,13 +57,13 @@ class UpdateHomebrewFormulaTest(unittest.TestCase):
             self.assertIn("depends_on :macos", output)
             self.assertIn("on_arm do", output)
             self.assertIn(
-                'url "https://github.com/tuchg/Lucarne/releases/download/v0.2.3/lucarned-v0.2.3-aarch64-apple-darwin.tar.gz"',
+                'url "https://github.com/tuchg/Lucarne/releases/download/v0.2.3/lucarned-v0.2.3-aarch64-apple-darwin.tar.xz"',
                 output,
             )
             self.assertIn(f'sha256 "{ARM_SHA}"', output)
             self.assertIn("on_intel do", output)
             self.assertIn(
-                'url "https://github.com/tuchg/Lucarne/releases/download/v0.2.3/lucarned-v0.2.3-x86_64-apple-darwin.tar.gz"',
+                'url "https://github.com/tuchg/Lucarne/releases/download/v0.2.3/lucarned-v0.2.3-x86_64-apple-darwin.tar.xz"',
                 output,
             )
             self.assertIn(f'sha256 "{X86_SHA}"', output)

--- a/scripts/release/update-homebrew-formula.py
+++ b/scripts/release/update-homebrew-formula.py
@@ -19,12 +19,12 @@ FORMULA_TEMPLATE = r'''class Lucarned < Formula
   stable do
     on_macos do
       on_arm do
-        url "https://github.com/tuchg/Lucarne/releases/download/v__VERSION__/lucarned-v__VERSION__-aarch64-apple-darwin.tar.gz"
+        url "https://github.com/tuchg/Lucarne/releases/download/v__VERSION__/lucarned-v__VERSION__-aarch64-apple-darwin.tar.xz"
         sha256 "__ARM64_SHA__"
       end
 
       on_intel do
-        url "https://github.com/tuchg/Lucarne/releases/download/v__VERSION__/lucarned-v__VERSION__-x86_64-apple-darwin.tar.gz"
+        url "https://github.com/tuchg/Lucarne/releases/download/v__VERSION__/lucarned-v__VERSION__-x86_64-apple-darwin.tar.xz"
         sha256 "__X86_64_SHA__"
       end
     end


### PR DESCRIPTION
## Summary
- Put release installer URLs first in README quick start.
- Keep Homebrew available in a folded section.
- Fold platform/autostart notes for supported systems.
- Mark Linux and Windows roadmap items complete.
- Bump workspace version to `0.3.0-rc.5` and harden cargo-dist CI based on prerelease verification.

## Release verification
- Created prerelease: https://github.com/tuchg/Lucarne/releases/tag/v0.3.0-rc.5
- Release workflow: https://github.com/tuchg/Lucarne/actions/runs/26266080730
- All six platform artifacts plus installers/checksums/source were uploaded.
- Archive asset names are versioned, e.g. `lucarned-v0.3.0-rc.5-aarch64-apple-darwin.tar.xz`.

## Fixes found during release test
- cargo-dist generated a container apt install without `-y`; added noninteractive apt config and `allow-dirty = ["ci"]` because the generated workflow is intentionally patched.
- Windows ARM64 cross build needed cargo-xwin clang backend for `psm` assembly.
- cargo-xwin clang sysroot needed a `Windows.h` case alias for bundled sqlite.
- cargo-dist archive names are unversioned by default; release workflow now versions archive/checksum assets and patches installers/release notes/manifest before creating the GitHub Release.
- Homebrew formula updater now points at the versioned `.tar.xz` macOS artifacts.

## Test Plan
- [x] `python3 scripts/release/test_update_homebrew_formula.py`
- [x] `cargo +nightly check -Zbuild-dir-new-layout -p lucarned --quiet`
- [x] `dist plan --tag v0.3.0-rc.5`
- [x] `git diff --check`
- [x] cargo-dist tag workflow for `v0.3.0-rc.5`