### PR TITLE
docs: recommend Homebrew in quick start

### DIFF
--- a/README.cn.md
+++ b/README.cn.md
@@ -67,17 +67,17 @@ lucarned init
 
 ### 3. 启动后台服务
 
-Homebrew：
-
 ```bash
-brew services start lucarned
+lucarned autostart install --start
 ```
 
 <details>
-<summary>其他安装方式</summary>
+<summary>Homebrew service 命令（推荐）</summary>
 
 ```bash
-lucarned autostart install --start
+brew services start lucarned
+brew services restart lucarned
+brew services stop lucarned
 ```
 
 </details>

--- a/README.cn.md
+++ b/README.cn.md
@@ -26,16 +26,6 @@
 
 ### 1. 安装
 
-推荐：Homebrew
-
-```bash
-brew tap tuchg/Lucarne https://github.com/tuchg/Lucarne
-brew install lucarned
-```
-
-<details>
-<summary>一键脚本与发布包</summary>
-
 macOS / Linux：
 
 ```bash
@@ -46,6 +36,16 @@ Windows PowerShell：
 
 ```powershell
 powershell -c "irm https://github.com/tuchg/Lucarne/releases/latest/download/lucarned-installer.ps1 | iex"
+```
+
+<details>
+<summary>Homebrew（推荐）与发布包</summary>
+
+Homebrew：
+
+```bash
+brew tap tuchg/Lucarne https://github.com/tuchg/Lucarne
+brew install lucarned
 ```
 
 也可以在 GitHub Releases 下载 macOS、Linux、Windows 的 x86_64 / aarch64 发布包。

--- a/README.cn.md
+++ b/README.cn.md
@@ -26,7 +26,15 @@
 
 ### 1. 安装
 
-推荐一键脚本：
+推荐：Homebrew
+
+```bash
+brew tap tuchg/Lucarne https://github.com/tuchg/Lucarne
+brew install lucarned
+```
+
+<details>
+<summary>一键脚本与发布包</summary>
 
 macOS / Linux：
 
@@ -38,16 +46,6 @@ Windows PowerShell：
 
 ```powershell
 powershell -c "irm https://github.com/tuchg/Lucarne/releases/latest/download/lucarned-installer.ps1 | iex"
-```
-
-<details>
-<summary>Homebrew 与发布包</summary>
-
-Homebrew：
-
-```bash
-brew tap tuchg/Lucarne https://github.com/tuchg/Lucarne
-brew install lucarned
 ```
 
 也可以在 GitHub Releases 下载 macOS、Linux、Windows 的 x86_64 / aarch64 发布包。
@@ -69,19 +67,17 @@ lucarned init
 
 ### 3. 启动后台服务
 
-推荐一键 autostart：
-
-```bash
-lucarned autostart install --start
-```
-
-<details>
-<summary>Homebrew service 可选命令</summary>
+Homebrew：
 
 ```bash
 brew services start lucarned
-brew services restart lucarned
-brew services stop lucarned
+```
+
+<details>
+<summary>其他安装方式</summary>
+
+```bash
+lucarned autostart install --start
 ```
 
 </details>
@@ -122,6 +118,8 @@ lucarned update
 <summary>Homebrew service 命令</summary>
 
 ```bash
+brew update
+brew upgrade lucarned
 brew services start lucarned
 brew services restart lucarned
 brew services stop lucarned

--- a/README.md
+++ b/README.md
@@ -26,16 +26,6 @@ English | [中文](README.cn.md)
 
 ### 1. Install
 
-Recommended: Homebrew
-
-```bash
-brew tap tuchg/Lucarne https://github.com/tuchg/Lucarne
-brew install lucarned
-```
-
-<details>
-<summary>One-line installers and release archives</summary>
-
 macOS / Linux:
 
 ```bash
@@ -46,6 +36,16 @@ Windows PowerShell:
 
 ```powershell
 powershell -c "irm https://github.com/tuchg/Lucarne/releases/latest/download/lucarned-installer.ps1 | iex"
+```
+
+<details>
+<summary>Homebrew (recommended) and release archives</summary>
+
+Homebrew:
+
+```bash
+brew tap tuchg/Lucarne https://github.com/tuchg/Lucarne
+brew install lucarned
 ```
 
 Release archives are also available for macOS, Linux, and Windows on x86_64 and aarch64.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,15 @@ English | [中文](README.cn.md)
 
 ### 1. Install
 
-Recommended one-line installers:
+Recommended: Homebrew
+
+```bash
+brew tap tuchg/Lucarne https://github.com/tuchg/Lucarne
+brew install lucarned
+```
+
+<details>
+<summary>One-line installers and release archives</summary>
 
 macOS / Linux:
 
@@ -38,16 +46,6 @@ Windows PowerShell:
 
 ```powershell
 powershell -c "irm https://github.com/tuchg/Lucarne/releases/latest/download/lucarned-installer.ps1 | iex"
-```
-
-<details>
-<summary>Homebrew and release archives</summary>
-
-Homebrew:
-
-```bash
-brew tap tuchg/Lucarne https://github.com/tuchg/Lucarne
-brew install lucarned
 ```
 
 Release archives are also available for macOS, Linux, and Windows on x86_64 and aarch64.
@@ -69,19 +67,17 @@ Initialization guides you through:
 
 ### 3. Start the background service
 
-Recommended one-command autostart:
-
-```bash
-lucarned autostart install --start
-```
-
-<details>
-<summary>Homebrew service alternative</summary>
+Homebrew:
 
 ```bash
 brew services start lucarned
-brew services restart lucarned
-brew services stop lucarned
+```
+
+<details>
+<summary>Other installs</summary>
+
+```bash
+lucarned autostart install --start
 ```
 
 </details>
@@ -122,6 +118,8 @@ lucarned update
 <summary>Homebrew service commands</summary>
 
 ```bash
+brew update
+brew upgrade lucarned
 brew services start lucarned
 brew services restart lucarned
 brew services stop lucarned

--- a/README.md
+++ b/README.md
@@ -67,17 +67,17 @@ Initialization guides you through:
 
 ### 3. Start the background service
 
-Homebrew:
-
 ```bash
-brew services start lucarned
+lucarned autostart install --start
 ```
 
 <details>
-<summary>Other installs</summary>
+<summary>Homebrew service commands (recommended)</summary>
 
 ```bash
-lucarned autostart install --start
+brew services start lucarned
+brew services restart lucarned
+brew services stop lucarned
 ```
 
 </details>

--- a/examples/lucarned.yaml
+++ b/examples/lucarned.yaml
@@ -27,6 +27,13 @@ config:
     bypass: false # Globally bypass agent permission prompts.
     notifications: true # Enable notifications globally.
 
+updates:
+  enabled: true # Check GitHub Releases for newer stable lucarned versions.
+  notify: true # Send Telegram/WeChat notifications when an update is available.
+  check_interval_hours: 24 # Minimum hours between GitHub release checks.
+  remind_interval_hours: 24 # Minimum hours between reminders for the same version.
+  repository: tuchg/Lucarne # GitHub repository to check.
+
 channels:
   telegram:
     enabled: true # Enable Telegram channel.


### PR DESCRIPTION
## Summary
- Put Homebrew back as the recommended install path.
- Move one-line installer scripts into folded alternatives.
- Use Homebrew service start as primary service start path.
- Add `brew update` / `brew upgrade lucarned` to folded Homebrew common commands.

## Test Plan
- [x] `git diff --check`