### PR TITLE
fix #34: preserve FIFO submitted turns

### DIFF
--- a/crates/lucarne-telegram/src/bot.rs
+++ b/crates/lucarne-telegram/src/bot.rs
@@ -64,7 +64,10 @@ use tracing::{debug, info, instrument, warn};
 use crate::{
     agents,
     channel::TelegramBotCommand,
-    state::{BotState, LiveSession, PanelSnapshot, PanelView, RunningCommandWorkflow, WorkSession},
+    state::{
+        BotState, LiveSession, PanelSnapshot, PanelView, RunningCommandWorkflow, RunningTurn,
+        WorkSession,
+    },
     turn,
 };
 use base64::Engine;
@@ -1635,6 +1638,48 @@ impl Bot {
         Ok(())
     }
 
+    async fn submit_and_drain_user_turn(
+        &self,
+        ws: &WorkspaceId,
+        handle: &WorkspaceHandle,
+        live: &LiveSession,
+        input: AgentInput,
+        provider_id: &str,
+        recorder: Arc<dyn turn::TurnEventRecorder>,
+        intervention_callback_registry: Option<Arc<dyn turn::AgentInterventionCallbackRegistry>>,
+        final_footer: Option<AgentMessageFooter>,
+        source_message: &MessageId,
+        reply_to: Option<MessageId>,
+    ) -> Result<(RunningTurn, turn::TurnRunReport), String> {
+        turn::prepare_turn_drain(live).await;
+        let _direct_notification_guard =
+            DirectNotificationGuard::new(self.state.core_handle(), ws.clone());
+        let running_turn = self
+            .state
+            .submit_user_turn(ws, input, Some(source_message))
+            .await
+            .map_err(|err| err.to_string())?;
+        debug!("prompt submitted");
+        let report = turn::drain_turn_with_options(
+            &self.channel,
+            handle,
+            live,
+            provider_id,
+            turn::TurnRunOptions {
+                recording: Some(turn::TurnRecording {
+                    turn_id: running_turn.turn_id.clone(),
+                    recorder,
+                }),
+                intervention_callback_registry,
+                final_footer,
+            },
+            reply_to,
+        )
+        .await?;
+        self.state.complete_turn(&running_turn)?;
+        Ok((running_turn, report))
+    }
+
     async fn run_workspace_turn(
         &self,
         ws: &WorkspaceId,
@@ -1715,35 +1760,23 @@ impl Bot {
         let recorder = recorder_scope.recorder(&self.state);
         let intervention_callback_registry =
             recorder_scope.intervention_callback_registry(&self.state);
-        let mut running_turn =
-            self.state
-                .start_user_turn(ws, &live, input.text.as_ref(), Some(source_message))?;
-        let _direct_notification_guard =
-            DirectNotificationGuard::new(Arc::clone(&self.core), ws.clone());
-        let report = match turn::run_turn_with_options(
-            &self.channel,
-            handle,
-            &live,
-            input.clone(),
-            session.provider_id,
-            turn::TurnRunOptions {
-                recording: Some(turn::TurnRecording {
-                    turn_id: running_turn.turn_id.clone(),
-                    recorder: Arc::clone(&recorder),
-                }),
-                intervention_callback_registry: intervention_callback_registry.clone(),
-                final_footer: final_footer.clone(),
-            },
-            reply_to.clone(),
-        )
-        .await
+        let (running_turn, report) = match self
+            .submit_and_drain_user_turn(
+                ws,
+                handle,
+                &live,
+                input.clone(),
+                session.provider_id,
+                Arc::clone(&recorder),
+                intervention_callback_registry.clone(),
+                final_footer.clone(),
+                source_message,
+                reply_to.clone(),
+            )
+            .await
         {
-            Ok(report) => {
-                self.state.complete_turn(&running_turn)?;
-                report
-            }
+            Ok((running_turn, report)) => (running_turn, report),
             Err(err) if is_recoverable_live_session_error(&err) => {
-                self.state.fail_turn(&running_turn, &err)?;
                 warn!(
                     target: "lucarne_telegram::bot",
                     error = %err,
@@ -1773,44 +1806,24 @@ impl Bot {
                 let retry_live = self
                     .ensure_live_bound(&mut retry_session, force_bypass_permissions)
                     .await?;
-                running_turn = self.state.start_user_turn(
-                    ws,
-                    &retry_live,
-                    input.text.as_ref(),
-                    Some(source_message),
-                )?;
-                let retry_report = match turn::run_turn_with_options(
-                    &self.channel,
-                    handle,
-                    &retry_live,
-                    input,
-                    session.provider_id,
-                    turn::TurnRunOptions {
-                        recording: Some(turn::TurnRecording {
-                            turn_id: running_turn.turn_id.clone(),
-                            recorder,
-                        }),
+                let retry_result = self
+                    .submit_and_drain_user_turn(
+                        ws,
+                        handle,
+                        &retry_live,
+                        input,
+                        session.provider_id,
+                        recorder,
                         intervention_callback_registry,
                         final_footer,
-                    },
-                    reply_to,
-                )
-                .await
-                {
-                    Ok(retry_report) => {
-                        self.state.complete_turn(&running_turn)?;
-                        retry_report
-                    }
-                    Err(retry_err) => {
-                        self.state.fail_turn(&running_turn, &retry_err)?;
-                        return Err(retry_err);
-                    }
-                };
+                        source_message,
+                        reply_to,
+                    )
+                    .await?;
                 live = retry_live;
-                retry_report
+                retry_result
             }
             Err(err) => {
-                self.state.fail_turn(&running_turn, &err)?;
                 let resume_ref = match session.resume_ref.clone() {
                     Some(resume_ref) => Some(resume_ref),
                     None => live_provider_resume_ref(&live).await,
@@ -3135,7 +3148,40 @@ impl Bot {
             let observed_close = live.session.observed_close_reason().await;
             if observed_close.is_none() {
                 let provider_ref_after = live_provider_resume_ref(&live).await;
-                if let (Some(expected_ref), Some(live_ref)) =
+                let core_workspace_id =
+                    lucarne::control_plane::WorkspaceId::new(session.workspace.as_str());
+                let core_live_instance_id = lucarne::control_plane::LiveInstanceId::new(
+                    live.session.instance_id().0.as_str(),
+                );
+                if !self
+                    .core
+                    .live_session_is_bound(&core_workspace_id, &core_live_instance_id)
+                {
+                    let resume_ref = match session.resume_ref.clone() {
+                        Some(resume_ref) => Some(resume_ref),
+                        None if self.should_keep_live_only_resume_ref(
+                            &session.workspace,
+                            None,
+                            provider_ref_after.as_deref(),
+                        ) =>
+                        {
+                            None
+                        }
+                        None => provider_ref_after.clone(),
+                    };
+                    warn!(
+                        target: "lucarne_telegram::bot",
+                        provider = session.provider_id,
+                        workspace = %session.workspace.as_str(),
+                        live_instance = %core_live_instance_id.as_str(),
+                        "discarding live session missing from core runtime registry before turn"
+                    );
+                    self.state
+                        .mark_live_dead(&session.workspace, resume_ref.clone())
+                        .map_err(|e| e.to_string())?;
+                    session.resume_ref = resume_ref;
+                    session.live = None;
+                } else if let (Some(expected_ref), Some(live_ref)) =
                     (session.resume_ref.clone(), provider_ref_after.clone())
                 {
                     if expected_ref != live_ref {
@@ -3216,9 +3262,17 @@ impl Bot {
                 return Err(err);
             }
         };
-        let resume_ref = live_provider_resume_ref(&live)
-            .await
-            .or_else(|| session.resume_ref.clone());
+        let provider_ref_after = live_provider_resume_ref(&live).await;
+        let keep_live_only = self.should_keep_live_only_resume_ref(
+            &session.workspace,
+            session.resume_ref.as_deref(),
+            provider_ref_after.as_deref(),
+        );
+        let resume_ref = if keep_live_only {
+            None
+        } else {
+            provider_ref_after.or_else(|| session.resume_ref.clone())
+        };
         self.state
             .bind_live(&session.workspace, live.clone(), resume_ref.clone())
             .map_err(|e| e.to_string())?;
@@ -7089,7 +7143,7 @@ mod tests {
     }
 
     fn test_bot_with_state(channel: Arc<RecordingChannel>, state: Arc<BotState>) -> Arc<Bot> {
-        let core = core_with_runtime(Arc::new(AgentRuntime::new()));
+        let core = state.core_handle();
         Arc::new(Bot::new_with_state(
             channel,
             core,
@@ -7535,12 +7589,11 @@ mod tests {
         std::fs::create_dir_all(&project).expect("project dir");
         std::fs::write(project.join("README.md"), "lucarne telegram live bot e2e\n")
             .expect("readme");
-        let db = temp.path().join("state.sqlite3");
         let channel = Arc::new(RecordingChannel::default());
         let runtime = Arc::new(AgentRuntime::new());
         runtime.register_defaults();
         let core = core_with_runtime(runtime);
-        let state = BotState::open_sqlite(&db).expect("open temp state");
+        let state = BotState::new_with_core(Arc::clone(&core));
         let bot = Arc::new(Bot::new_with_state(
             channel.clone(),
             core,
@@ -7607,9 +7660,8 @@ mod tests {
             ProtocolProvider::new(active_provider.adapter()).expect("recorded provider"),
         ));
         let core = core_with_runtime(Arc::new(runtime));
-        let db = temp.path().join("state.sqlite3");
         let channel = Arc::new(RecordingChannel::default());
-        let state = BotState::open_sqlite(&db).expect("open temp state");
+        let state = BotState::new_with_core(Arc::clone(&core));
         let bot = Arc::new(Bot::new_with_state(
             channel.clone(),
             core,
@@ -7712,12 +7764,11 @@ mod tests {
             ("LUCARNE_TELEGRAM_LIVE_TIMEOUT", OsString::from("5")),
         ]);
 
-        let db = temp.path().join("state.sqlite3");
         let channel = Arc::new(RecordingChannel::default());
         let runtime = Arc::new(AgentRuntime::new());
         runtime.register_defaults();
         let core = core_with_runtime(runtime);
-        let state = BotState::open_sqlite(&db).expect("open temp state");
+        let state = BotState::new_with_core(Arc::clone(&core));
         let bot = Arc::new(Bot::new_with_state(
             channel.clone(),
             core,

--- a/crates/lucarne-telegram/src/state.rs
+++ b/crates/lucarne-telegram/src/state.rs
@@ -8,7 +8,9 @@ use lucarne::agent_runtime::{
     AgentCapabilities, AgentError, AgentErrorKind, AgentProvider, AgentRuntime, OpenSession,
     ProbeResult, ProviderId, ResumeSession,
 };
-use lucarne::agent_runtime::{AgentForkTargetCatalog, AgentImageInput, AgentStatus, InstanceId};
+use lucarne::agent_runtime::{
+    AgentForkTargetCatalog, AgentImageInput, AgentInput, AgentStatus, InstanceId,
+};
 #[cfg(test)]
 use lucarne::control_plane::ControlPlaneSqliteStore;
 use lucarne::control_plane::{
@@ -21,7 +23,7 @@ use lucarne::control_plane::{
     WorkspaceId as ControlWorkspaceId,
 };
 use lucarne::core_service::{
-    CoreWorkspaceEventStream, DaemonSession, LucarneCore, OpenWorkspaceRequest,
+    CoreWorkspaceEventStream, DaemonSession, LucarneCore, OpenWorkspaceRequest, SubmitTurnRequest,
     TimelineKindProjection, TimelineProjectionItem,
 };
 use lucarne::event::SubAgentCall;
@@ -290,6 +292,32 @@ impl BotState {
             chat,
             &WorkspaceId::new(topic_id.as_str()),
         ));
+    }
+
+    pub fn core_handle(&self) -> Arc<LucarneCore> {
+        Arc::clone(&self.core)
+    }
+
+    pub async fn submit_user_turn(
+        &self,
+        ws: &WorkspaceId,
+        input: AgentInput,
+        reply_to: Option<&MessageId>,
+    ) -> Result<RunningTurn, String> {
+        let submitted = self
+            .core
+            .submit_turn(SubmitTurnRequest {
+                workspace_id: control_workspace_id(ws),
+                source: TurnSource::UserMessage,
+                input,
+                reply_to_channel_message_id: reply_to
+                    .and_then(|id| id.as_str().parse::<i64>().ok()),
+            })
+            .await
+            .map_err(|err| err.to_string())?;
+        Ok(RunningTurn {
+            turn_id: submitted.turn_id,
+        })
     }
 
     fn sync_core_session(
@@ -1691,6 +1719,7 @@ impl BotState {
         )
     }
 
+    #[cfg(test)]
     pub fn start_user_turn(
         &self,
         ws: &WorkspaceId,

--- a/crates/lucarne-telegram/src/turn.rs
+++ b/crates/lucarne-telegram/src/turn.rs
@@ -16,9 +16,11 @@
 
 use base64::Engine as _;
 #[cfg(test)]
+use lucarne::agent_runtime::AgentInput;
+#[cfg(test)]
 use lucarne::agent_runtime::InterventionRequest;
 use lucarne::agent_runtime::{
-    AgentCommandInvocation, AgentCommandResult, AgentCommandResultData, AgentInput, AgentStatus,
+    AgentCommandInvocation, AgentCommandResult, AgentCommandResultData, AgentStatus,
     Attachment as AgentAttachment, CommandResultEvent, Event, InstanceId, MessageEvent,
     MessageRole,
 };
@@ -447,15 +449,7 @@ fn log_event_json(value: &serde_json::Value) -> String {
     log_event_text(&value.to_string(), EVENT_LOG_TEXT_MAX)
 }
 
-pub(crate) async fn run_turn_with_options(
-    channel: &Arc<dyn Channel>,
-    target: &WorkspaceHandle,
-    live: &LiveSession,
-    input: AgentInput,
-    provider_id: &str,
-    options: TurnRunOptions,
-    reply_to: Option<MessageId>,
-) -> Result<TurnRunReport, String> {
+pub(crate) async fn prepare_turn_drain(live: &LiveSession) {
     // 0. Drop any leftover events from a prior turn. With
     //    `Event::TurnCompleted` now being the authoritative end-of-turn
     //    signal, this should almost always be empty in practice — if
@@ -471,14 +465,16 @@ pub(crate) async fn run_turn_with_options(
             "discarded stale events from previous turn (inspect logs above for event kinds)"
         );
     }
+}
 
-    // 1. Submit the prompt.
-    live.session
-        .submit_turn(input)
-        .await
-        .map_err(|e| e.to_string())?;
-    debug!("prompt submitted");
-
+pub(crate) async fn drain_turn_with_options(
+    channel: &Arc<dyn Channel>,
+    target: &WorkspaceHandle,
+    live: &LiveSession,
+    provider_id: &str,
+    options: TurnRunOptions,
+    reply_to: Option<MessageId>,
+) -> Result<TurnRunReport, String> {
     drain_submitted_events(
         channel,
         target,

--- a/crates/lucarne-telegram/src/turn/projection.rs
+++ b/crates/lucarne-telegram/src/turn/projection.rs
@@ -56,10 +56,9 @@ pub(super) struct ActiveDraft {
     pub(super) last_render: String,
 }
 
-/// Streaming output for a single turn. The live assistant bubble is a
-/// normal channel message edited in place, then edited one last time
-/// into the final reply. This keeps Telegram from replaying the same
-/// text in a new message when the turn completes.
+/// Streaming output for a single turn. Assistant message chunks update a silent
+/// live preview bubble and track a final candidate. Once the provider emits
+/// `TurnCompleted`, the final candidate is sent as the formal answer.
 pub(super) struct DraftStream {
     pub(super) current: Option<ActiveDraft>,
     /// Latest assistant text candidate to commit as the formal final

--- a/crates/lucarne-telegram/tests/topic_routing_integration.rs
+++ b/crates/lucarne-telegram/tests/topic_routing_integration.rs
@@ -29,7 +29,7 @@ use lucarne::{
         ReasoningEvent, ResumeSession, SessionId, SessionRef, ToolCallEvent, ToolResultEvent,
     },
     control_plane::{
-        ChannelBinding, ChannelBindingId, ControlPlaneSqliteStore, ProviderSessionId,
+        ChannelBinding, ChannelBindingId, ControlPlaneSqliteStore, ProviderSessionId, TurnSource,
         WorkspaceId as ControlWorkspaceId,
     },
     core_service::{LucarneCore, OpenWorkspaceRequest, ResumeWorkspaceRequest, SubmitTurnRequest},
@@ -2224,10 +2224,12 @@ async fn live_record_watch_notification_replay_cassette_codex() {
         live_watch_recording_timeout(),
         core.submit_turn(SubmitTurnRequest {
             workspace_id: workspace_id.clone(),
+            source: TurnSource::UserMessage,
             input: AgentInput {
                 text: background_prompt.into(),
                 images: Vec::new(),
             },
+            reply_to_channel_message_id: None,
         }),
     )
     .await
@@ -2420,7 +2422,7 @@ async fn watch_does_not_duplicate_notifications_for_active_bot_conversation() {
             .all(|(_, title, _)| title != "agent notifications"),
         "normal topic conversations should not create notification topics"
     );
-    let mut answer_message_ids = topic_messages(&channel, "9")
+    let mut answer_message_ids = active_topic_messages(&channel, "9")
         .iter()
         .filter(|sent| sent.message.body.contains("normal topic answer"))
         .map(|sent| sent.id.clone())

--- a/crates/lucarne-wechat/src/service.rs
+++ b/crates/lucarne-wechat/src/service.rs
@@ -18,8 +18,8 @@ use lucarne::{
         Event as AgentEvent, InterventionRequest, MessageRole,
     },
     control_plane::{
-        MessageSessionBinding, ProviderSessionId, StatusSnapshot, TurnId, WorkspaceBinding,
-        WorkspaceId,
+        MessageSessionBinding, ProviderSessionId, StatusSnapshot, TurnId, TurnSource,
+        WorkspaceBinding, WorkspaceId,
     },
     core_service::{
         AgentResourceEntry, AgentResourceScope, AgentResourceSnapshot, CoreEvent, KillAgentReport,
@@ -1650,7 +1650,9 @@ where
             .core
             .submit_turn(SubmitTurnRequest {
                 workspace_id: workspace_id.clone(),
+                source: TurnSource::UserMessage,
                 input,
+                reply_to_channel_message_id: None,
             })
             .await;
         let submitted = match submit {

--- a/crates/lucarne/src/control_plane/turn_queue.rs
+++ b/crates/lucarne/src/control_plane/turn_queue.rs
@@ -1,12 +1,12 @@
 use super::types::WorkspaceId;
 use std::{
-    collections::HashMap,
-    sync::{Arc, Mutex as StdMutex, RwLock as StdRwLock},
+    collections::{HashMap, VecDeque},
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc, Mutex as StdMutex, RwLock as StdRwLock,
+    },
 };
-use tokio::{
-    sync::{Mutex as AsyncMutex, OwnedMutexGuard},
-    task::JoinHandle,
-};
+use tokio::sync::oneshot;
 use tracing::debug;
 
 #[derive(Debug)]
@@ -36,7 +36,8 @@ pub struct QueuedTurn {
     workspace_id: WorkspaceId,
     position: usize,
     scheduler: TurnScheduler,
-    waiter: Option<JoinHandle<OwnedMutexGuard<()>>>,
+    waiter: Option<Arc<QueuedWaiter>>,
+    receiver: Option<oneshot::Receiver<()>>,
     counted: bool,
 }
 
@@ -46,17 +47,18 @@ impl QueuedTurn {
     }
 
     pub async fn wait(mut self) -> TurnPermit {
-        let guard = self
-            .waiter
+        self.receiver
             .take()
-            .expect("queued turn waiter")
+            .expect("queued turn receiver")
             .await
-            .expect("queued turn waiter task");
-        self.scheduler.note_dequeued(&self.workspace_id);
+            .expect("queued turn grant");
+        self.scheduler.note_handoff_started(&self.workspace_id);
         self.counted = false;
+        self.waiter = None;
         TurnPermit {
             queued_position: Some(self.position),
-            _guard: guard,
+            workspace_id: self.workspace_id.clone(),
+            scheduler: self.scheduler.clone(),
         }
     }
 }
@@ -65,9 +67,15 @@ impl Drop for QueuedTurn {
     fn drop(&mut self) {
         if self.counted {
             if let Some(waiter) = self.waiter.take() {
-                waiter.abort();
+                waiter.cancel();
+                match self.scheduler.cancel_queued(&self.workspace_id, waiter.id) {
+                    CancelOutcome::Removed => {}
+                    CancelOutcome::PendingHandoff => {
+                        self.scheduler.release_next(&self.workspace_id);
+                    }
+                    CancelOutcome::Missing => {}
+                }
             }
-            self.scheduler.note_dequeued(&self.workspace_id);
         }
     }
 }
@@ -75,7 +83,8 @@ impl Drop for QueuedTurn {
 #[derive(Debug)]
 pub struct TurnPermit {
     queued_position: Option<usize>,
-    _guard: OwnedMutexGuard<()>,
+    workspace_id: WorkspaceId,
+    scheduler: TurnScheduler,
 }
 
 impl TurnPermit {
@@ -84,10 +93,16 @@ impl TurnPermit {
     }
 }
 
+impl Drop for TurnPermit {
+    fn drop(&mut self) {
+        self.scheduler.release_next(&self.workspace_id);
+    }
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct TurnScheduler {
-    locks: Arc<StdRwLock<HashMap<WorkspaceId, Arc<AsyncMutex<()>>>>>,
-    waiters: Arc<StdMutex<HashMap<WorkspaceId, usize>>>,
+    queues: Arc<StdRwLock<HashMap<WorkspaceId, Arc<StdMutex<WorkspaceQueue>>>>>,
+    next_waiter_id: Arc<AtomicU64>,
 }
 
 impl TurnScheduler {
@@ -96,81 +111,173 @@ impl TurnScheduler {
     }
 
     pub fn admit(&self, workspace_id: &WorkspaceId) -> TurnAdmission {
-        let lock = self.workspace_lock(workspace_id);
-        match lock.clone().try_lock_owned() {
-            Ok(guard) => {
-                debug!(
-                    target: "lucarne::control_plane::turn_queue",
-                    workspace_id = %workspace_id.as_str(),
-                    "turn admitted"
-                );
-                TurnAdmission::Ready(TurnPermit {
-                    queued_position: None,
-                    _guard: guard,
-                })
-            }
-            Err(_) => {
-                let position = self.note_queued(workspace_id);
-                debug!(
-                    target: "lucarne::control_plane::turn_queue",
-                    workspace_id = %workspace_id.as_str(),
-                    position,
-                    "turn queued"
-                );
-                let waiter = tokio::spawn(async move { lock.lock_owned().await });
-                TurnAdmission::Queued(QueuedTurn {
-                    workspace_id: workspace_id.clone(),
-                    position,
-                    scheduler: self.clone(),
-                    waiter: Some(waiter),
-                    counted: true,
-                })
-            }
+        let queue = self.workspace_queue(workspace_id);
+        let mut state = queue.lock().expect("turn scheduler workspace queue");
+        if !state.active && !state.handoff_pending && state.waiters.is_empty() {
+            state.active = true;
+            debug!(
+                target: "lucarne::control_plane::turn_queue",
+                workspace_id = %workspace_id.as_str(),
+                "turn admitted"
+            );
+            return TurnAdmission::Ready(TurnPermit {
+                queued_position: None,
+                workspace_id: workspace_id.clone(),
+                scheduler: self.clone(),
+            });
         }
+
+        let position = state.waiters.len() + usize::from(state.handoff_pending) + 1;
+        let (tx, rx) = oneshot::channel();
+        let waiter = Arc::new(QueuedWaiter {
+            id: self.next_waiter_id.fetch_add(1, Ordering::Relaxed),
+            grant: StdMutex::new(Some(tx)),
+        });
+        state.waiters.push_back(Arc::clone(&waiter));
+        debug!(
+            target: "lucarne::control_plane::turn_queue",
+            workspace_id = %workspace_id.as_str(),
+            position,
+            "turn queued"
+        );
+        TurnAdmission::Queued(QueuedTurn {
+            workspace_id: workspace_id.clone(),
+            position,
+            scheduler: self.clone(),
+            waiter: Some(waiter),
+            receiver: Some(rx),
+            counted: true,
+        })
     }
 
     pub async fn acquire(&self, workspace_id: &WorkspaceId) -> TurnPermit {
         self.admit(workspace_id).wait().await
     }
 
-    fn workspace_lock(&self, workspace_id: &WorkspaceId) -> Arc<AsyncMutex<()>> {
-        if let Some(lock) = self
-            .locks
+    fn workspace_queue(&self, workspace_id: &WorkspaceId) -> Arc<StdMutex<WorkspaceQueue>> {
+        if let Some(queue) = self
+            .queues
             .read()
             .expect("turn scheduler lock registry")
             .get(workspace_id)
             .cloned()
         {
-            return lock;
+            return queue;
         }
 
-        self.locks
+        self.queues
             .write()
             .expect("turn scheduler lock registry")
             .entry(workspace_id.clone())
-            .or_insert_with(|| Arc::new(AsyncMutex::new(())))
+            .or_insert_with(|| Arc::new(StdMutex::new(WorkspaceQueue::default())))
             .clone()
     }
 
-    fn note_queued(&self, workspace_id: &WorkspaceId) -> usize {
-        let mut waiters = self.waiters.lock().unwrap();
-        let count = waiters.entry(workspace_id.clone()).or_insert(0);
-        *count += 1;
-        *count
-    }
-
-    fn note_dequeued(&self, workspace_id: &WorkspaceId) {
-        let mut waiters = self.waiters.lock().unwrap();
-        match waiters.get_mut(workspace_id) {
-            Some(1) => {
-                waiters.remove(workspace_id);
+    fn release_next(&self, workspace_id: &WorkspaceId) {
+        let Some(queue) = self.existing_workspace_queue(workspace_id) else {
+            return;
+        };
+        loop {
+            let next = {
+                let mut state = queue.lock().expect("turn scheduler workspace queue");
+                state.handoff_pending = false;
+                match state.waiters.pop_front() {
+                    Some(waiter) => {
+                        state.active = true;
+                        state.handoff_pending = true;
+                        Some(waiter)
+                    }
+                    None => {
+                        state.active = false;
+                        None
+                    }
+                }
+            };
+            let Some(waiter) = next else {
+                return;
+            };
+            if waiter.grant() {
+                return;
             }
-            Some(count) => {
-                *count -= 1;
-            }
-            None => {}
         }
     }
+
+    fn note_handoff_started(&self, workspace_id: &WorkspaceId) {
+        if let Some(queue) = self.existing_workspace_queue(workspace_id) {
+            queue
+                .lock()
+                .expect("turn scheduler workspace queue")
+                .handoff_pending = false;
+        }
+    }
+
+    fn cancel_queued(&self, workspace_id: &WorkspaceId, waiter_id: u64) -> CancelOutcome {
+        let Some(queue) = self.existing_workspace_queue(workspace_id) else {
+            return CancelOutcome::Missing;
+        };
+        let mut state = queue.lock().expect("turn scheduler workspace queue");
+        if let Some(index) = state
+            .waiters
+            .iter()
+            .position(|waiter| waiter.id == waiter_id)
+        {
+            state.waiters.remove(index);
+            return CancelOutcome::Removed;
+        }
+        if state.handoff_pending {
+            state.handoff_pending = false;
+            return CancelOutcome::PendingHandoff;
+        }
+        CancelOutcome::Missing
+    }
+
+    fn existing_workspace_queue(
+        &self,
+        workspace_id: &WorkspaceId,
+    ) -> Option<Arc<StdMutex<WorkspaceQueue>>> {
+        self.queues
+            .read()
+            .expect("turn scheduler lock registry")
+            .get(workspace_id)
+            .cloned()
+    }
+}
+
+#[derive(Debug, Default)]
+struct WorkspaceQueue {
+    active: bool,
+    handoff_pending: bool,
+    waiters: VecDeque<Arc<QueuedWaiter>>,
+}
+
+#[derive(Debug)]
+struct QueuedWaiter {
+    id: u64,
+    grant: StdMutex<Option<oneshot::Sender<()>>>,
+}
+
+impl QueuedWaiter {
+    fn grant(&self) -> bool {
+        self.grant
+            .lock()
+            .expect("turn scheduler queued waiter")
+            .take()
+            .is_some_and(|grant| grant.send(()).is_ok())
+    }
+
+    fn cancel(&self) {
+        self.grant
+            .lock()
+            .expect("turn scheduler queued waiter")
+            .take();
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CancelOutcome {
+    Removed,
+    PendingHandoff,
+    Missing,
 }
 
 #[cfg(test)]
@@ -230,7 +337,7 @@ mod tests {
     }
 
     #[test]
-    fn turn_scheduler_uses_read_optimized_workspace_lock_registry() {
+    fn turn_scheduler_uses_read_optimized_workspace_queue_registry() {
         let source = std::fs::read_to_string(
             std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
                 .join("src/control_plane/turn_queue.rs"),
@@ -242,12 +349,14 @@ mod tests {
             .expect("production source");
 
         assert!(
-            production.contains("locks: Arc<StdRwLock<HashMap<WorkspaceId, Arc<AsyncMutex<()>>>>>"),
-            "workspace lock registry should allow read-only lookups without taking an exclusive map lock"
+            production.contains(
+                "queues: Arc<StdRwLock<HashMap<WorkspaceId, Arc<StdMutex<WorkspaceQueue>>>>>"
+            ),
+            "workspace queue registry should allow read-only lookups without taking an exclusive map lock"
         );
         assert!(
-            !production.contains("locks: Arc<StdMutex<HashMap<WorkspaceId, Arc<AsyncMutex<()>>>>>"),
-            "workspace lock registry should not use a global mutex for every turn admission"
+            !production.contains("queues: Arc<StdMutex<HashMap<WorkspaceId, WorkspaceQueue>>>"),
+            "workspace queue registry should not use a global mutex for every turn admission"
         );
     }
 
@@ -280,13 +389,48 @@ mod tests {
         assert_eq!(
             later.queued_position(),
             Some(2),
-            "a later turn must not overtake a queued turn while Telegram sends its queue notice"
+            "a later turn must not overtake a queued turn while the caller sends its queue notice"
         );
 
         drop(queued);
         timeout(Duration::from_secs(1), later.wait())
             .await
             .expect("later turn should acquire after queued turn is cancelled");
+    }
+
+    #[tokio::test]
+    async fn later_turn_cannot_overtake_unpolled_queued_turn_after_release() {
+        let scheduler = TurnScheduler::new();
+        let workspace = WorkspaceId::new("ws");
+        let first = scheduler.acquire(&workspace).await;
+
+        let queued = scheduler.admit(&workspace);
+        assert_eq!(queued.queued_position(), Some(1));
+        drop(first);
+
+        let later = scheduler.admit(&workspace);
+        assert_eq!(
+            later.queued_position(),
+            Some(2),
+            "a later turn must queue behind the older turn even before the older caller awaits its permit"
+        );
+
+        let later = tokio::spawn(async move { later.wait().await });
+        sleep(Duration::from_millis(20)).await;
+        assert!(
+            !later.is_finished(),
+            "later turn must not acquire before the older queued turn is awaited and released"
+        );
+
+        let queued = timeout(Duration::from_secs(1), queued.wait())
+            .await
+            .expect("older queued turn should acquire");
+        drop(queued);
+        let later = timeout(Duration::from_secs(1), later)
+            .await
+            .expect("later turn should acquire after older queued turn releases")
+            .expect("later turn task");
+        assert_eq!(later.queued_position(), Some(2));
     }
 
     #[tokio::test]

--- a/crates/lucarne/src/core_service/service.rs
+++ b/crates/lucarne/src/core_service/service.rs
@@ -36,7 +36,8 @@ use crate::{
         ProviderSessionId, ProviderSessionRecord, ReconcileOutcome, Revision, ScheduledTaskId,
         ScheduledTaskRecord, StatusSnapshot, SubAgentActionRecord, SubAgentCallbackRecord,
         SubAgentCallbackToken, SubAgentLinkId, SubAgentLinkRecord, SystemSettings, TimelineItem,
-        TimelineItemKind, TurnId, TurnRecord, TurnSource, TurnState, WorkspaceBinding, WorkspaceId,
+        TimelineItemKind, TurnId, TurnPermit, TurnRecord, TurnScheduler, TurnSource, TurnState,
+        WorkspaceBinding, WorkspaceId,
     },
     dialect::PermissionMode,
     host::process_table::{self, ProcessAggregate, ProcessSample},
@@ -85,7 +86,7 @@ impl From<ControlPlaneError> for CoreError {
 
 pub struct LucarneCore {
     runtime: Arc<AgentRuntime>,
-    state: RwLock<ControlPlaneState>,
+    state: Arc<RwLock<ControlPlaneState>>,
     store: ControlPlaneSqliteStore,
     provider_ids: Vec<&'static str>,
     events: broadcast::Sender<CoreEvent>,
@@ -96,10 +97,11 @@ pub struct LucarneCore {
     live_runtime_terminal_text_claims:
         Arc<RwLock<HashMap<LiveRuntimeTerminalTextClaimKey, Instant>>>,
     next_live_generation: AtomicU64,
+    submitted_turn_scheduler: TurnScheduler,
     submitted_turns: Arc<RwLock<HashMap<WorkspaceId, VecDeque<TurnId>>>>,
     submitted_turn_activity: Arc<RwLock<HashMap<TurnId, SubmittedTurnActivity>>>,
+    submitted_turn_permits: Arc<RwLock<HashMap<TurnId, TurnPermit>>>,
     live_runtime_turn_claims: Arc<RwLock<HashMap<LiveRuntimeTurnClaimKey, Instant>>>,
-    next_submitted_turn: AtomicU64,
     notification_suppression: RwLock<HashMap<WorkspaceId, usize>>,
     notification_suppression_grace: RwLock<HashMap<WorkspaceId, Instant>>,
     history_watch_started: AtomicBool,
@@ -300,7 +302,7 @@ impl LucarneCore {
         );
         Ok(Arc::new(Self {
             runtime,
-            state: RwLock::new(state),
+            state: Arc::new(RwLock::new(state)),
             store,
             history: crate::history::HistoryIndex::new(history_providers, Duration::from_secs(30)),
             provider_ids,
@@ -310,10 +312,11 @@ impl LucarneCore {
             live_session_generations: Arc::new(RwLock::new(HashMap::new())),
             live_runtime_terminal_text_claims: Arc::new(RwLock::new(HashMap::new())),
             next_live_generation: AtomicU64::new(0),
+            submitted_turn_scheduler: TurnScheduler::new(),
             submitted_turns: Arc::new(RwLock::new(HashMap::new())),
             submitted_turn_activity: Arc::new(RwLock::new(HashMap::new())),
+            submitted_turn_permits: Arc::new(RwLock::new(HashMap::new())),
             live_runtime_turn_claims: Arc::new(RwLock::new(HashMap::new())),
-            next_submitted_turn: AtomicU64::new(0),
             notification_suppression: RwLock::new(HashMap::new()),
             notification_suppression_grace: RwLock::new(HashMap::new()),
             history_watch_started: AtomicBool::new(false),
@@ -1456,10 +1459,33 @@ impl LucarneCore {
     pub async fn submit_turn(&self, req: SubmitTurnRequest) -> Result<SubmittedTurn, CoreError> {
         let SubmitTurnRequest {
             workspace_id,
+            source,
             input,
+            reply_to_channel_message_id,
         } = req;
+        let turn_permit = self.submitted_turn_scheduler.acquire(&workspace_id).await;
         let live = self.live_session(&workspace_id).await?;
-        let turn_id = self.next_submitted_turn_id();
+        let provider_session_id = self.active_provider_session_id(&workspace_id)?;
+        let live_instance_id = LiveInstanceId::new(live.instance_id().0.as_str());
+        let input_text = input.text.clone();
+        let turn = self.start_turn(
+            workspace_id.clone(),
+            provider_session_id,
+            live_instance_id,
+            source,
+            input_text.clone(),
+            reply_to_channel_message_id,
+        )?;
+        if source == TurnSource::UserMessage {
+            self.append_timeline(TimelineItem::new(
+                workspace_id.clone(),
+                turn.turn_id.clone(),
+                TimelineItemKind::User,
+                serde_json::json!({ "text": input_text.as_str() }),
+            ))?;
+        }
+        let turn_id = turn.turn_id;
+        self.remember_submitted_turn(workspace_id.clone(), turn_id.clone(), turn_permit);
         debug!(
             target: "lucarne::core_service",
             workspace_id = %workspace_id.as_str(),
@@ -1468,10 +1494,20 @@ impl LucarneCore {
             image_count = input.images.len(),
             "submitting turn"
         );
-        self.remember_submitted_turn(workspace_id.clone(), turn_id.clone());
         self.spawn_submitted_turn_watchdog(workspace_id.clone(), turn_id.clone());
         if let Err(err) = live.submit(input).await {
-            self.remove_submitted_turn(&workspace_id, &turn_id);
+            let error = err.to_string();
+            if let Err(fail_err) = self.fail_turn(turn_id.clone(), &error) {
+                warn!(
+                    target: "lucarne::core_service",
+                    workspace_id = %workspace_id.as_str(),
+                    turn_id = %turn_id.as_str(),
+                    submit_error = %error,
+                    fail_error = %fail_err,
+                    "failed to mark turn failed after live submit error"
+                );
+                self.remove_submitted_turn(&workspace_id, &turn_id);
+            }
             return Err(err.into());
         }
         let _ = self.events.send(CoreEvent::TurnStarted { workspace_id });
@@ -1572,10 +1608,12 @@ impl LucarneCore {
         let submitted = self
             .submit_turn(SubmitTurnRequest {
                 workspace_id: task.workspace_id.clone(),
+                source: TurnSource::System,
                 input: crate::agent_runtime::AgentInput {
                     text: task.prompt.to_string().into(),
                     images: Vec::new(),
                 },
+                reply_to_channel_message_id: None,
             })
             .await?;
         let updated_task = {
@@ -1604,6 +1642,18 @@ impl LucarneCore {
             .interrupt()
             .await?;
         Ok(())
+    }
+
+    pub fn live_session_is_bound(
+        &self,
+        workspace_id: &WorkspaceId,
+        live_instance_id: &LiveInstanceId,
+    ) -> bool {
+        self.live_sessions
+            .read()
+            .expect("live session registry lock")
+            .get(workspace_id)
+            .is_some_and(|session| session.instance_id().0.as_str() == live_instance_id.as_str())
     }
 
     pub async fn resolve_permission(&self, req: ResolvePermissionRequest) -> Result<(), CoreError> {
@@ -2111,10 +2161,13 @@ impl LucarneCore {
         let workspace_events = self.workspace_event_sender(&workspace_id);
         let submitted_turns = Arc::clone(&self.submitted_turns);
         let submitted_turn_activity = Arc::clone(&self.submitted_turn_activity);
+        let submitted_turn_permits = Arc::clone(&self.submitted_turn_permits);
         let live_sessions = Arc::clone(&self.live_sessions);
         let live_session_generations = Arc::clone(&self.live_session_generations);
         let live_runtime_turn_claims = Arc::clone(&self.live_runtime_turn_claims);
         let live_runtime_terminal_text_claims = Arc::clone(&self.live_runtime_terminal_text_claims);
+        let state = Arc::clone(&self.state);
+        let store = self.store.clone();
         let provider_id = session.provider_id();
         tokio::spawn(async move {
             let mut last_assistant_message: Option<SmolStr> = None;
@@ -2186,7 +2239,7 @@ impl LucarneCore {
                         }
                         let lifecycle = match &event {
                             AgentEvent::TurnCompleted(completed) => {
-                                if turn_id.is_some() {
+                                if let Some(turn_id) = turn_id.as_ref() {
                                     let native_session = session
                                         .provider_session_id()
                                         .await
@@ -2209,6 +2262,33 @@ impl LucarneCore {
                                             );
                                         }
                                     }
+                                    let usage = completed
+                                        .usage
+                                        .clone()
+                                        .map(serde_json::to_value)
+                                        .transpose()
+                                        .map_err(|err| {
+                                            CoreError::invalid_state(format!(
+                                                "failed to serialize turn completion usage: {err}"
+                                            ))
+                                        });
+                                    match usage.and_then(|usage| {
+                                        complete_turn_record_with_usage_value(
+                                            &store,
+                                            &state,
+                                            turn_id.clone(),
+                                            usage,
+                                        )
+                                    }) {
+                                        Ok(_) => {}
+                                        Err(err) => warn!(
+                                            target: "lucarne::core_service",
+                                            workspace_id = %workspace_id.as_str(),
+                                            turn_id = %turn_id.as_str(),
+                                            error = %err,
+                                            "failed to complete submitted turn record"
+                                        ),
+                                    }
                                 }
                                 last_assistant_message = None;
                                 Some(CoreEvent::TurnCompleted {
@@ -2216,7 +2296,7 @@ impl LucarneCore {
                                 })
                             }
                             AgentEvent::TurnFailed(failed) => {
-                                if turn_id.is_some() {
+                                if let Some(turn_id) = turn_id.as_ref() {
                                     let native_session = session
                                         .provider_session_id()
                                         .await
@@ -2229,6 +2309,20 @@ impl LucarneCore {
                                         ),
                                         failed.turn_id.clone(),
                                     );
+                                    if let Err(err) = fail_turn_record(
+                                        &store,
+                                        &state,
+                                        turn_id.clone(),
+                                        failed.error.as_str(),
+                                    ) {
+                                        warn!(
+                                            target: "lucarne::core_service",
+                                            workspace_id = %workspace_id.as_str(),
+                                            turn_id = %turn_id.as_str(),
+                                            error = %err,
+                                            "failed to fail submitted turn record"
+                                        );
+                                    }
                                 }
                                 last_assistant_message = None;
                                 Some(CoreEvent::TurnFailed {
@@ -2256,6 +2350,7 @@ impl LucarneCore {
                                 pop_submitted_turn(
                                     &submitted_turns,
                                     &submitted_turn_activity,
+                                    &submitted_turn_permits,
                                     &workspace_id,
                                 );
                             }
@@ -2268,9 +2363,19 @@ impl LucarneCore {
                 if pop_submitted_turn_if_current(
                     &submitted_turns,
                     &submitted_turn_activity,
+                    &submitted_turn_permits,
                     &workspace_id,
                     &turn_id,
                 ) {
+                    if let Err(err) = fail_turn_record(&store, &state, turn_id.clone(), &error) {
+                        warn!(
+                            target: "lucarne::core_service",
+                            workspace_id = %workspace_id.as_str(),
+                            turn_id = %turn_id.as_str(),
+                            error = %err,
+                            "failed to fail submitted turn record after event stream closed"
+                        );
+                    }
                     emit_submitted_turn_failure(
                         &events,
                         &workspace_events,
@@ -3485,15 +3590,6 @@ impl LucarneCore {
             (turn, entities)
         };
         self.upsert_persistence_entities(entities)?;
-        if matches!(source, TurnSource::UserMessage | TurnSource::Command)
-            && self
-                .live_sessions
-                .read()
-                .expect("live session registry lock")
-                .contains_key(&turn.workspace_id)
-        {
-            self.remember_submitted_turn(turn.workspace_id.clone(), turn.turn_id.clone());
-        }
         Ok(turn)
     }
 
@@ -3560,32 +3656,12 @@ impl LucarneCore {
         turn_id: TurnId,
         usage: Option<serde_json::Value>,
     ) -> Result<(), CoreError> {
-        let Some(turn_record) = self.store.turn(&turn_id)? else {
-            return Err(ControlPlaneError::MissingTurn(turn_id).into());
-        };
-        let live_owner = self
-            .store
-            .workspace_id_for_live_instance(&turn_record.live_instance_id)?;
-        let Some(live_record) = self.store.live_instance(&turn_record.live_instance_id)? else {
-            return Err(
-                ControlPlaneError::MissingLiveInstance(turn_record.live_instance_id).into(),
-            );
-        };
-        let (workspace_id, live_instance_id, entities) = {
-            let mut state = self.state.write().expect("control plane lock");
-            state.record_turn_projection(turn_record);
-            state.record_live_instance_projection(live_record, live_owner);
-            let turn = state.complete_turn_with_usage(turn_id.clone(), usage)?;
-            let workspace_id = turn.workspace_id;
-            let live_instance_id = turn.live_instance_id.clone();
-            let entities = state.persistence_entities_for_turn_lifecycle(&turn_id);
-            (workspace_id, live_instance_id, entities)
-        };
-        self.store
-            .delete_intervention_callbacks_for_live_instances(std::slice::from_ref(
-                &live_instance_id,
-            ))?;
-        self.upsert_persistence_entities(entities)?;
+        let workspace_id = complete_turn_record_with_usage_value(
+            &self.store,
+            &self.state,
+            turn_id.clone(),
+            usage,
+        )?;
         self.remove_submitted_turn(&workspace_id, &turn_id);
         Ok(())
     }
@@ -3654,32 +3730,7 @@ impl LucarneCore {
     }
 
     pub fn fail_turn(&self, turn_id: TurnId, error: &str) -> Result<(), CoreError> {
-        let Some(turn_record) = self.store.turn(&turn_id)? else {
-            return Err(ControlPlaneError::MissingTurn(turn_id).into());
-        };
-        let live_owner = self
-            .store
-            .workspace_id_for_live_instance(&turn_record.live_instance_id)?;
-        let Some(live_record) = self.store.live_instance(&turn_record.live_instance_id)? else {
-            return Err(
-                ControlPlaneError::MissingLiveInstance(turn_record.live_instance_id).into(),
-            );
-        };
-        let (workspace_id, live_instance_id, entities) = {
-            let mut state = self.state.write().expect("control plane lock");
-            state.record_turn_projection(turn_record);
-            state.record_live_instance_projection(live_record, live_owner);
-            let turn = state.fail_turn(turn_id.clone(), error)?;
-            let workspace_id = turn.workspace_id;
-            let live_instance_id = turn.live_instance_id.clone();
-            let entities = state.persistence_entities_for_turn_lifecycle(&turn_id);
-            (workspace_id, live_instance_id, entities)
-        };
-        self.store
-            .delete_intervention_callbacks_for_live_instances(std::slice::from_ref(
-                &live_instance_id,
-            ))?;
-        self.upsert_persistence_entities(entities)?;
+        let workspace_id = fail_turn_record(&self.store, &self.state, turn_id.clone(), error)?;
         self.remove_submitted_turn(&workspace_id, &turn_id);
         Ok(())
     }
@@ -4019,6 +4070,10 @@ impl LucarneCore {
                 .write()
                 .expect("submitted turn activity lock")
                 .retain(|turn_id, _| !removed_turns.contains(turn_id));
+            self.submitted_turn_permits
+                .write()
+                .expect("submitted turn permit lock")
+                .retain(|turn_id, _| !removed_turns.contains(turn_id));
         }
         session
     }
@@ -4081,12 +4136,12 @@ impl LucarneCore {
             .ok_or_else(|| CoreError::invalid_state("workspace has no live session"))
     }
 
-    fn next_submitted_turn_id(&self) -> TurnId {
-        let next = self.next_submitted_turn.fetch_add(1, Ordering::SeqCst) + 1;
-        TurnId::new(format!("submitted-turn-{next}"))
-    }
-
-    fn remember_submitted_turn(&self, workspace_id: WorkspaceId, turn_id: TurnId) {
+    fn remember_submitted_turn(
+        &self,
+        workspace_id: WorkspaceId,
+        turn_id: TurnId,
+        turn_permit: TurnPermit,
+    ) {
         let now = Instant::now();
         self.submitted_turns
             .write()
@@ -4098,12 +4153,16 @@ impl LucarneCore {
             .write()
             .expect("submitted turn activity lock")
             .insert(
-                turn_id,
+                turn_id.clone(),
                 SubmittedTurnActivity {
                     last_event_at: now,
                     waiting_intervention: false,
                 },
             );
+        self.submitted_turn_permits
+            .write()
+            .expect("submitted turn permit lock")
+            .insert(turn_id, turn_permit);
     }
 
     fn remove_submitted_turn(&self, workspace_id: &WorkspaceId, turn_id: &TurnId) {
@@ -4118,6 +4177,7 @@ impl LucarneCore {
             .write()
             .expect("submitted turn activity lock")
             .remove(turn_id);
+        release_submitted_turn_permit(&self.submitted_turn_permits, turn_id);
     }
 
     fn spawn_submitted_turn_watchdog(&self, workspace_id: WorkspaceId, turn_id: TurnId) {
@@ -4125,6 +4185,9 @@ impl LucarneCore {
         let workspace_events = self.workspace_event_sender(&workspace_id);
         let submitted_turns = Arc::clone(&self.submitted_turns);
         let submitted_turn_activity = Arc::clone(&self.submitted_turn_activity);
+        let submitted_turn_permits = Arc::clone(&self.submitted_turn_permits);
+        let state = Arc::clone(&self.state);
+        let store = self.store.clone();
         let options = self.options.clone();
         tokio::spawn(async move {
             loop {
@@ -4154,6 +4217,7 @@ impl LucarneCore {
                 if !pop_submitted_turn_if_current(
                     &submitted_turns,
                     &submitted_turn_activity,
+                    &submitted_turn_permits,
                     &workspace_id,
                     &turn_id,
                 ) {
@@ -4166,6 +4230,15 @@ impl LucarneCore {
                     error = %error,
                     "submitted turn watchdog failed stuck live turn without closing live session"
                 );
+                if let Err(err) = fail_turn_record(&store, &state, turn_id.clone(), &error) {
+                    warn!(
+                        target: "lucarne::core_service",
+                        workspace_id = %workspace_id.as_str(),
+                        turn_id = %turn_id.as_str(),
+                        error = %err,
+                        "failed to fail submitted turn record after watchdog timeout"
+                    );
+                }
                 emit_submitted_turn_failure(
                     &events,
                     &workspace_events,
@@ -4177,6 +4250,66 @@ impl LucarneCore {
             }
         });
     }
+}
+
+fn complete_turn_record_with_usage_value(
+    store: &ControlPlaneSqliteStore,
+    state: &Arc<RwLock<ControlPlaneState>>,
+    turn_id: TurnId,
+    usage: Option<serde_json::Value>,
+) -> Result<WorkspaceId, CoreError> {
+    let Some(turn_record) = store.turn(&turn_id)? else {
+        return Err(ControlPlaneError::MissingTurn(turn_id).into());
+    };
+    let live_owner = store.workspace_id_for_live_instance(&turn_record.live_instance_id)?;
+    let Some(live_record) = store.live_instance(&turn_record.live_instance_id)? else {
+        return Err(ControlPlaneError::MissingLiveInstance(turn_record.live_instance_id).into());
+    };
+    let (workspace_id, live_instance_id, entities) = {
+        let mut state = state.write().expect("control plane lock");
+        state.record_turn_projection(turn_record);
+        state.record_live_instance_projection(live_record, live_owner);
+        let turn = state.complete_turn_with_usage(turn_id.clone(), usage)?;
+        let workspace_id = turn.workspace_id;
+        let live_instance_id = turn.live_instance_id.clone();
+        let entities = state.persistence_entities_for_turn_lifecycle(&turn_id);
+        (workspace_id, live_instance_id, entities)
+    };
+    store.delete_intervention_callbacks_for_live_instances(std::slice::from_ref(
+        &live_instance_id,
+    ))?;
+    store.upsert_entities(entities)?;
+    Ok(workspace_id)
+}
+
+fn fail_turn_record(
+    store: &ControlPlaneSqliteStore,
+    state: &Arc<RwLock<ControlPlaneState>>,
+    turn_id: TurnId,
+    error: &str,
+) -> Result<WorkspaceId, CoreError> {
+    let Some(turn_record) = store.turn(&turn_id)? else {
+        return Err(ControlPlaneError::MissingTurn(turn_id).into());
+    };
+    let live_owner = store.workspace_id_for_live_instance(&turn_record.live_instance_id)?;
+    let Some(live_record) = store.live_instance(&turn_record.live_instance_id)? else {
+        return Err(ControlPlaneError::MissingLiveInstance(turn_record.live_instance_id).into());
+    };
+    let (workspace_id, live_instance_id, entities) = {
+        let mut state = state.write().expect("control plane lock");
+        state.record_turn_projection(turn_record);
+        state.record_live_instance_projection(live_record, live_owner);
+        let turn = state.fail_turn(turn_id.clone(), error)?;
+        let workspace_id = turn.workspace_id;
+        let live_instance_id = turn.live_instance_id.clone();
+        let entities = state.persistence_entities_for_turn_lifecycle(&turn_id);
+        (workspace_id, live_instance_id, entities)
+    };
+    store.delete_intervention_callbacks_for_live_instances(std::slice::from_ref(
+        &live_instance_id,
+    ))?;
+    store.upsert_entities(entities)?;
+    Ok(workspace_id)
 }
 
 async fn recv_agent_activity(activity_source: &mut Option<AgentActivityStream>) -> Option<()> {
@@ -4364,6 +4497,7 @@ fn submitted_turn_is_current(
 fn pop_submitted_turn(
     submitted_turns: &Arc<RwLock<HashMap<WorkspaceId, VecDeque<TurnId>>>>,
     activity: &Arc<RwLock<HashMap<TurnId, SubmittedTurnActivity>>>,
+    permits: &Arc<RwLock<HashMap<TurnId, TurnPermit>>>,
     workspace_id: &WorkspaceId,
 ) {
     let mut submitted_turns = submitted_turns.write().expect("submitted turn lock");
@@ -4380,12 +4514,14 @@ fn pop_submitted_turn(
             .write()
             .expect("submitted turn activity lock")
             .remove(&turn_id);
+        release_submitted_turn_permit(permits, &turn_id);
     }
 }
 
 fn pop_submitted_turn_if_current(
     submitted_turns: &Arc<RwLock<HashMap<WorkspaceId, VecDeque<TurnId>>>>,
     activity: &Arc<RwLock<HashMap<TurnId, SubmittedTurnActivity>>>,
+    permits: &Arc<RwLock<HashMap<TurnId, TurnPermit>>>,
     workspace_id: &WorkspaceId,
     turn_id: &TurnId,
 ) -> bool {
@@ -4405,7 +4541,18 @@ fn pop_submitted_turn_if_current(
         .write()
         .expect("submitted turn activity lock")
         .remove(turn_id);
+    release_submitted_turn_permit(permits, turn_id);
     true
+}
+
+fn release_submitted_turn_permit(
+    permits: &Arc<RwLock<HashMap<TurnId, TurnPermit>>>,
+    turn_id: &TurnId,
+) {
+    permits
+        .write()
+        .expect("submitted turn permit lock")
+        .remove(turn_id);
 }
 
 fn mark_current_submitted_turn_intervention_resolved(
@@ -4851,6 +4998,7 @@ mod tests {
     use agent_sessions::{
         WatchAssistantMessage, WatchAttachment, WatchEventMeta, WatchMessage, WatchTurnFailed,
     };
+    use tokio::sync::Notify;
 
     static ENV_LOCK: StdMutex<()> = StdMutex::new(());
 
@@ -5768,20 +5916,24 @@ mod tests {
         let first = core
             .submit_turn(SubmitTurnRequest {
                 workspace_id: opened.workspace.workspace_id.clone(),
+                source: TurnSource::UserMessage,
                 input: crate::agent_runtime::AgentInput {
                     text: "first".into(),
                     images: Vec::new(),
                 },
+                reply_to_channel_message_id: None,
             })
             .await
             .expect("submit first");
         let second = core
             .submit_turn(SubmitTurnRequest {
                 workspace_id: opened.workspace.workspace_id.clone(),
+                source: TurnSource::UserMessage,
                 input: crate::agent_runtime::AgentInput {
                     text: "second".into(),
                     images: Vec::new(),
                 },
+                reply_to_channel_message_id: None,
             })
             .await
             .expect("submit second");
@@ -5814,6 +5966,88 @@ mod tests {
                 (first.turn_id, "reply: first".into()),
                 (second.turn_id, "reply: second".into())
             ]
+        );
+    }
+
+    #[tokio::test]
+    async fn submit_turns_wait_for_prior_turn_completion_per_workspace() {
+        let state = Arc::new(BlockingSubmitState::default());
+        let runtime = Arc::new(AgentRuntime::new());
+        runtime.register(Arc::new(BlockingSubmitProvider {
+            state: Arc::clone(&state),
+        }));
+        let core = LucarneCore::from_runtime_and_store(
+            runtime,
+            ControlPlaneSqliteStore::open_in_memory().expect("store"),
+        )
+        .expect("core");
+        let opened = core
+            .open_workspace_with_events(OpenWorkspaceRequest {
+                provider_id: "codex",
+                project_path: Some(PathBuf::from("/tmp/submitted-turn-fifo")),
+                title: "submitted turn fifo".into(),
+            })
+            .await
+            .expect("open workspace");
+        let workspace_id = opened.workspace.workspace_id.clone();
+
+        let first_core = Arc::clone(&core);
+        let first_workspace = workspace_id.clone();
+        let first = tokio::spawn(async move {
+            first_core
+                .submit_turn(SubmitTurnRequest {
+                    workspace_id: first_workspace,
+                    source: TurnSource::UserMessage,
+                    input: crate::agent_runtime::AgentInput {
+                        text: "first".into(),
+                        images: Vec::new(),
+                    },
+                    reply_to_channel_message_id: None,
+                })
+                .await
+        });
+        tokio::time::timeout(Duration::from_secs(1), state.first_submitted.notified())
+            .await
+            .expect("first submit should reach provider");
+
+        let second_core = Arc::clone(&core);
+        let second_workspace = workspace_id.clone();
+        let second = tokio::spawn(async move {
+            second_core
+                .submit_turn(SubmitTurnRequest {
+                    workspace_id: second_workspace,
+                    source: TurnSource::UserMessage,
+                    input: crate::agent_runtime::AgentInput {
+                        text: "second".into(),
+                        images: Vec::new(),
+                    },
+                    reply_to_channel_message_id: None,
+                })
+                .await
+        });
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert_eq!(
+            state.submitted_inputs(),
+            vec!["first".to_string()],
+            "a newer inbound submit must not reach the provider before the older turn completes"
+        );
+
+        state.release_first.notify_one();
+        let first = tokio::time::timeout(Duration::from_secs(1), first)
+            .await
+            .expect("first submit task should finish")
+            .expect("first submit task")
+            .expect("first submit");
+        let second = tokio::time::timeout(Duration::from_secs(1), second)
+            .await
+            .expect("second submit task should finish after first completes")
+            .expect("second submit task")
+            .expect("second submit");
+
+        assert_ne!(first.turn_id, second.turn_id);
+        assert_eq!(
+            state.submitted_inputs(),
+            vec!["first".to_string(), "second".to_string()]
         );
     }
 
@@ -7233,10 +7467,12 @@ mod tests {
         let submitted = core
             .submit_turn(SubmitTurnRequest {
                 workspace_id: opened.workspace.workspace_id.clone(),
+                source: TurnSource::UserMessage,
                 input: crate::agent_runtime::AgentInput {
                     text: "please continue".into(),
                     images: Vec::new(),
                 },
+                reply_to_channel_message_id: None,
             })
             .await
             .expect("submit turn");
@@ -7348,10 +7584,12 @@ mod tests {
         let submitted = core
             .submit_turn(SubmitTurnRequest {
                 workspace_id: opened.workspace.workspace_id.clone(),
+                source: TurnSource::UserMessage,
                 input: crate::agent_runtime::AgentInput {
                     text: "please continue".into(),
                     images: Vec::new(),
                 },
+                reply_to_channel_message_id: None,
             })
             .await
             .expect("submit turn");
@@ -7620,10 +7858,12 @@ mod tests {
         let submitted = core
             .submit_turn(SubmitTurnRequest {
                 workspace_id: workspace_id.clone(),
+                source: TurnSource::UserMessage,
                 input: crate::agent_runtime::AgentInput {
                     text: "please continue".into(),
                     images: Vec::new(),
                 },
+                reply_to_channel_message_id: None,
             })
             .await
             .expect("submit turn");
@@ -8475,6 +8715,61 @@ mod tests {
         }
     }
 
+    struct BlockingSubmitState {
+        inputs: StdMutex<Vec<String>>,
+        first_submitted: Notify,
+        release_first: Notify,
+    }
+
+    impl Default for BlockingSubmitState {
+        fn default() -> Self {
+            Self {
+                inputs: StdMutex::new(Vec::new()),
+                first_submitted: Notify::new(),
+                release_first: Notify::new(),
+            }
+        }
+    }
+
+    impl BlockingSubmitState {
+        fn submitted_inputs(&self) -> Vec<String> {
+            self.inputs.lock().expect("submitted inputs lock").clone()
+        }
+    }
+
+    struct BlockingSubmitProvider {
+        state: Arc<BlockingSubmitState>,
+    }
+
+    #[async_trait]
+    impl AgentProvider for BlockingSubmitProvider {
+        fn id(&self) -> ProviderId {
+            ProviderId::from_static("codex")
+        }
+
+        async fn probe(&self) -> Result<ProbeResult, AgentError> {
+            Ok(ProbeResult {
+                provider_id: ProviderId::from_static("codex"),
+                provider_version: Some("test".into()),
+                capabilities: Default::default(),
+            })
+        }
+
+        async fn open(&self, _req: OpenSession) -> Result<Box<dyn AgentSession>, AgentError> {
+            Ok(Box::new(BlockingSubmitSession::new(
+                "blocking-submit-open",
+                Arc::clone(&self.state),
+            )))
+        }
+
+        async fn resume(&self, req: ResumeSession) -> Result<Box<dyn AgentSession>, AgentError> {
+            Ok(Box::new(BlockingSubmitSession::new(
+                req.session_ref.0.as_str(),
+                Arc::clone(&self.state),
+            )))
+        }
+    }
+
     #[derive(Default)]
     struct CompletingProvider {
         next: StdMutex<u64>,
@@ -8523,6 +8818,102 @@ mod tests {
                 tx,
                 events: StdMutex::new(Some(rx)),
             }
+        }
+    }
+
+    struct BlockingSubmitSession {
+        id: SessionId,
+        instance_id: InstanceId,
+        state: Arc<BlockingSubmitState>,
+        tx: tokio::sync::mpsc::Sender<AgentEvent>,
+        events: StdMutex<Option<AgentEventStream>>,
+    }
+
+    impl BlockingSubmitSession {
+        fn new(id: &str, state: Arc<BlockingSubmitState>) -> Self {
+            let (tx, rx) = tokio::sync::mpsc::channel(16);
+            Self {
+                id: SessionId(id.into()),
+                instance_id: InstanceId(format!("instance-{id}").into()),
+                state,
+                tx,
+                events: StdMutex::new(Some(rx)),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl AgentSession for BlockingSubmitSession {
+        fn id(&self) -> &SessionId {
+            &self.id
+        }
+
+        fn instance_id(&self) -> &InstanceId {
+            &self.instance_id
+        }
+
+        fn provider_id(&self) -> ProviderId {
+            ProviderId::from_static("codex")
+        }
+
+        async fn submit(&self, input: crate::agent_runtime::AgentInput) -> Result<(), AgentError> {
+            let text = input.text.to_string();
+            self.state
+                .inputs
+                .lock()
+                .expect("submitted inputs lock")
+                .push(text.clone());
+            if text == "first" {
+                self.state.first_submitted.notify_one();
+                self.state.release_first.notified().await;
+            }
+            self.tx
+                .send(AgentEvent::Message(crate::agent_runtime::MessageEvent {
+                    role: crate::agent_runtime::MessageRole::Assistant,
+                    text: format!("reply: {text}").into(),
+                    streaming: false,
+                }))
+                .await
+                .map_err(|err| AgentError {
+                    kind: AgentErrorKind::Internal,
+                    message: err.to_string().into(),
+                })?;
+            self.tx
+                .send(AgentEvent::TurnCompleted(TurnCompletedEvent {
+                    turn_id: format!("provider-turn-{text}").into(),
+                    usage: None,
+                }))
+                .await
+                .map_err(|err| AgentError {
+                    kind: AgentErrorKind::Internal,
+                    message: err.to_string().into(),
+                })?;
+            Ok(())
+        }
+
+        async fn interrupt(&self) -> Result<(), AgentError> {
+            Ok(())
+        }
+
+        async fn resolve(
+            &self,
+            _req_id: &str,
+            _response: crate::agent_runtime::InterventionResponse,
+        ) -> Result<(), AgentError> {
+            Ok(())
+        }
+
+        async fn take_events(&self) -> Result<AgentEventStream, AgentError> {
+            Ok(self
+                .events
+                .lock()
+                .unwrap()
+                .take()
+                .expect("events already taken"))
+        }
+
+        async fn close(&self) -> Result<(), AgentError> {
+            Ok(())
         }
     }
 
@@ -8928,10 +9319,12 @@ mod tests {
     async fn submit_noop_turn(core: &LucarneCore, workspace_id: &WorkspaceId) -> SubmittedTurn {
         core.submit_turn(SubmitTurnRequest {
             workspace_id: workspace_id.clone(),
+            source: TurnSource::UserMessage,
             input: crate::agent_runtime::AgentInput {
                 text: "please continue".into(),
                 images: Vec::new(),
             },
+            reply_to_channel_message_id: None,
         })
         .await
         .expect("submit turn")

--- a/crates/lucarne/src/core_service/types.rs
+++ b/crates/lucarne/src/core_service/types.rs
@@ -13,7 +13,7 @@ use crate::{
     },
     control_plane::{
         InterventionCallbackToken, LiveInstanceId, ProviderSessionId, Revision, ScheduledTaskId,
-        TurnId, WorkspaceId,
+        TurnId, TurnSource, WorkspaceId,
     },
     history::{HistoryEntry, HistoryWorkspace},
 };
@@ -72,7 +72,9 @@ pub struct ResumeWorkspaceRequest {
 #[derive(Debug, Clone)]
 pub struct SubmitTurnRequest {
     pub workspace_id: WorkspaceId,
+    pub source: TurnSource,
     pub input: AgentInput,
+    pub reply_to_channel_message_id: Option<i64>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/lucarne/tests/core_service_boundary.rs
+++ b/crates/lucarne/tests/core_service_boundary.rs
@@ -7,7 +7,7 @@ use lucarne::{
         AgentProvider, AgentSession, Event, InstanceId, InterventionResponse, MessageEvent,
         MessageRole, OpenSession, ProbeResult, ResumeSession, SessionId,
     },
-    control_plane::{ControlPlaneSqliteStore, ScheduledTaskId, WorkspaceId},
+    control_plane::{ControlPlaneSqliteStore, ScheduledTaskId, TurnSource, WorkspaceId},
     core_service::{
         CoreEvent, DaemonApi, OpenWorkspaceRequest, ResumeWorkspaceRequest,
         RunDueScheduledTasksRequest, UpsertScheduledTaskRequest,
@@ -41,7 +41,7 @@ fn core_service_does_not_write_sqlite_while_holding_state_mutex() {
         "live session registry should not use an async mutex for in-memory map access"
     );
     assert!(
-        service.contains("state: RwLock<ControlPlaneState>"),
+        service.contains("state: Arc<RwLock<ControlPlaneState>>"),
         "core control-plane cache should allow concurrent read-only daemon queries"
     );
     assert!(
@@ -602,10 +602,12 @@ async fn core_pumps_provider_events_to_daemon_event_stream() {
 
     core.submit_turn(lucarne::core_service::SubmitTurnRequest {
         workspace_id: workspace_id.clone(),
+        source: TurnSource::UserMessage,
         input: AgentInput {
             text: "hello".into(),
             images: vec![],
         },
+        reply_to_channel_message_id: None,
     })
     .await
     .expect("submit");
@@ -679,10 +681,12 @@ async fn journey_34_dual_channel_core_event_delivers_to_both_telegram_and_wechat
 
     core.submit_turn(lucarne::core_service::SubmitTurnRequest {
         workspace_id: workspace_id.clone(),
+        source: TurnSource::UserMessage,
         input: AgentInput {
             text: "notify both".into(),
             images: vec![],
         },
+        reply_to_channel_message_id: None,
     })
     .await
     .expect("submit turn");

--- a/crates/lucarne/tests/core_service_stress.rs
+++ b/crates/lucarne/tests/core_service_stress.rs
@@ -14,8 +14,7 @@ use lucarne::{
         MessageRole, OpenSession, ProbeResult, ResumeSession, SessionId,
     },
     control_plane::{
-        ControlPlaneSqliteStore, LiveInstanceId, TimelineItem, TimelineItemKind, TurnSource,
-        WorkspaceId,
+        ControlPlaneSqliteStore, TimelineItem, TimelineItemKind, TurnSource, WorkspaceId,
     },
     core_service::{OpenWorkspaceRequest, SubmitTurnRequest},
     LucarneCore, ProviderId,
@@ -103,33 +102,22 @@ async fn exercise_workspace(
         )
         .await
         .map_err(|err| err.to_string())?;
-    let provider_session_id = core
-        .active_provider_session_id(&workspace_id)
-        .map_err(|err| err.to_string())?;
-    let live_instance_id = LiveInstanceId::new(opened.session.instance_id().0.clone());
     let mut events = opened.events;
 
     for turn_idx in 0..turns_per_workspace {
         let input = format!("stress input {workspace_idx}:{turn_idx}");
-        let turn = core
-            .start_turn(
-                workspace_id.clone(),
-                provider_session_id.clone(),
-                live_instance_id.clone(),
-                TurnSource::UserMessage,
-                input.clone(),
-                None,
-            )
+        let submitted = core
+            .submit_turn(SubmitTurnRequest {
+                workspace_id: workspace_id.clone(),
+                source: TurnSource::UserMessage,
+                input: AgentInput {
+                    text: input.into(),
+                    images: Vec::new(),
+                },
+                reply_to_channel_message_id: None,
+            })
+            .await
             .map_err(|err| err.to_string())?;
-        core.submit_turn(SubmitTurnRequest {
-            workspace_id: workspace_id.clone(),
-            input: AgentInput {
-                text: input.into(),
-                images: Vec::new(),
-            },
-        })
-        .await
-        .map_err(|err| err.to_string())?;
 
         let mut saw_assistant = false;
         let mut saw_completed = false;
@@ -142,7 +130,7 @@ async fn exercise_workspace(
                 Event::Message(message) if message.role == MessageRole::Assistant => {
                     core.append_timeline(TimelineItem::new(
                         workspace_id.clone(),
-                        turn.turn_id.clone(),
+                        submitted.turn_id.clone(),
                         TimelineItemKind::Assistant,
                         serde_json::json!({ "text": message.text }),
                     ))
@@ -150,8 +138,6 @@ async fn exercise_workspace(
                     saw_assistant = true;
                 }
                 Event::TurnCompleted(_) => {
-                    core.complete_turn_with_usage_value(turn.turn_id.clone(), None)
-                        .map_err(|err| err.to_string())?;
                     saw_completed = true;
                 }
                 other => return Err(format!("unexpected workspace event: {other:?}")),

--- a/docs/decisions/2026-06-01-turn-queue-fifo-admission.md
+++ b/docs/decisions/2026-06-01-turn-queue-fifo-admission.md
@@ -1,0 +1,62 @@
+# Turn Queue FIFO Admission
+
+## Context
+
+WeChat can receive a second reply for the same routed workspace while the older
+submitted turn is still waiting for provider output. `LucarneCore::submit_turn`
+previously recorded submitted turns only for event attribution. After the
+provider accepted input, the API returned and a later caller could submit another
+input to the same live session before the older turn emitted completion or
+failure.
+
+The old scheduler also counted queued turns separately from the mutex waiter
+that actually owned order. A later admission could acquire the mutex during the
+gap between an older queued turn being counted and that waiter's task being
+polled.
+
+## Decision
+
+Per-workspace FIFO order is owned by `TurnScheduler` admission and represented
+as an explicit in-memory queue. A permit owns the active turn; releasing it
+grants exactly the next queued waiter before any later admission can become
+ready. A granted-but-not-yet-awaited waiter still counts as ahead of later
+turns.
+
+`LucarneCore::submit_turn` is the single user-message live submission entry.
+It acquires a per-workspace permit, opens the durable control-plane turn, records
+the inbound user timeline item, submits to the live session, and stores the
+permit with that turn lifecycle. The permit is released only when the submitted
+turn completes, fails, times out, or is explicitly removed with the live
+workspace. Provider and channel integrations do not own this ordering policy.
+
+`start_turn` remains a control-plane lifecycle primitive for command workflows
+and tests, but it no longer registers a submitted turn or participates in live
+admission. Channels must not pre-open a user turn and then submit directly to the
+provider session.
+
+Channel projections may still record channel-side artifacts while draining
+events. Telegram re-applies turn completion after its drain finishes so
+permission callbacks registered from earlier events cannot outlive a completed
+turn when the core event pump observes `TurnCompleted` before the channel
+projection consumes all queued events. This is lifecycle cleanup, not a second
+provider submission path.
+
+## Consequences
+
+- Queue order no longer depends on Tokio task polling order for spawned mutex
+  waiters.
+- A newer same-workspace inbound message cannot reach the provider until the
+  older submitted turn has left the current submitted-turn slot.
+- There is no compatibility path that reuses a previously opened user turn.
+  Mixing `start_turn` with `submit_turn` is rejected by the control-plane live
+  state instead of being silently accepted.
+- Queue semantics remain provider-agnostic; WeChat and any other caller that
+  enters through `submit_turn` use the same core lifecycle.
+- Telegram normal user turns enter through `submit_turn`; command workflows keep
+  using the provider command API because that is a distinct provider capability,
+  not a user-message submit.
+- Bot state and the daemon core must refer to the same live runtime registry.
+  A cached live handle that is absent from the core registry is discarded and
+  reopened/resumed before the next user-message turn instead of submitting
+  directly to the stale handle.
+- Providers still own provider parsing, resume, discovery, and session behavior.


### PR DESCRIPTION
## Summary
- make `LucarneCore::submit_turn` the single user-message live submission entry and remove the `start_turn` submitted-turn compatibility path
- create durable turn records inside core submit, hold FIFO permits until terminal lifecycle, and route Telegram/WeChat user-message submission through that policy
- keep Telegram projection cleanup after drain so late-registered permission callbacks cannot outlive completed turns; document the decision in `docs/decisions/2026-06-01-turn-queue-fifo-admission.md`

## Verification
- `cargo +nightly check -Zbuild-dir-new-layout`
- `cargo +nightly test -Zbuild-dir-new-layout --workspace --all-features -- --quiet`
- `cargo +nightly test -Zbuild-dir-new-layout --workspace --all-features journey -- --nocapture`
- focused: FIFO core tests, `core_service_stress`, Telegram active-conversation notification test, and `lucarne-telegram turn::`

Fixes #34