### PR TITLE
feat: 通知页脚用项目目录名替代UUID会话标识

### DIFF
--- a/crates/lucarne-telegram/src/bot.rs
+++ b/crates/lucarne-telegram/src/bot.rs
@@ -1739,11 +1739,12 @@ impl Bot {
         }
         let mut live = session.live.clone().expect("bound above");
         let final_footer = include_agent_footer.then(|| {
-            let session_ref = self
-                .state
-                .active_provider_session_ref(&session.workspace)
-                .ok()
-                .or_else(|| session.resume_ref.clone())
+            // Use project directory basename instead of UUID session ref
+            let session_label = session
+                .project_path
+                .as_ref()
+                .and_then(|p| p.file_name())
+                .map(|n| n.to_string_lossy().to_string())
                 .unwrap_or_else(|| "-".to_string());
             let cwd = session
                 .project_path
@@ -1752,7 +1753,7 @@ impl Bot {
                 .unwrap_or_else(|| "-".to_string());
             AgentMessageFooter {
                 cost: None,
-                session: Some(session_ref),
+                session: Some(session_label),
                 cwd: Some(cwd),
             }
         });
@@ -5107,7 +5108,14 @@ fn render_agent_notification(
     session_ref: Option<&str>,
     text: &str,
 ) -> OutgoingMessage {
-    let session_ref = session_ref.unwrap_or("-");
+    // Use project directory basename (e.g. "tank-battle") instead of UUID session ref
+    let session_label = session
+        .project_path
+        .as_ref()
+        .and_then(|p| p.file_name())
+        .map(|n| n.to_string_lossy().to_string())
+        .or_else(|| session_ref.map(|s| s.to_string()))
+        .unwrap_or_else(|| "-".to_string());
     let cwd = session
         .project_path
         .as_ref()
@@ -5118,7 +5126,7 @@ fn render_agent_notification(
         text.as_ref(),
         &AgentMessageFooter {
             cost: None,
-            session: Some(session_ref.to_string()),
+            session: Some(session_label),
             cwd: Some(cwd),
         },
     );

--- a/crates/lucarne-wechat/src/service.rs
+++ b/crates/lucarne-wechat/src/service.rs
@@ -2833,7 +2833,13 @@ fn render_agent_message(
     if let Some(cost) = cost.as_deref().or(extracted_cost) {
         footer_lines.push(format!("耗时：{cost}"));
     }
-    footer_lines.push(format!("会话：{session_ref}"));
+    // Use project directory basename (e.g. "tank-battle") instead of UUID
+    let workspace_name = workspace
+        .project_path
+        .file_name()
+        .map(|n| n.to_string_lossy().to_string())
+        .unwrap_or_else(|| session_ref.to_string());
+    footer_lines.push(format!("项目：{workspace_name}"));
     footer_lines.push(format!(
         "目录：{}",
         compact_path(&workspace.project_path.display().to_string(), 58)
@@ -3614,11 +3620,16 @@ fn render_wechat_new_usage() -> &'static str {
 
 fn render_wechat_new_session(
     provider_id: &str,
-    session_ref: &str,
+    _session_ref: &str,
     workspace: &WorkspaceBinding,
 ) -> String {
+    let workspace_name = workspace
+        .project_path
+        .file_name()
+        .map(|n| n.to_string_lossy().to_string())
+        .unwrap_or_else(|| _session_ref.to_string());
     format!(
-        "🆕 新的 {provider_id} 会话\n目录：`{}`\n会话：`{session_ref}`\n\n回复此消息即可开始。",
+        "🆕 新的 {provider_id} 会话\n目录：`{}`\n项目：{workspace_name}\n\n回复此消息即可开始。",
         workspace.project_path.display()
     )
 }


### PR DESCRIPTION
## 改动说明

把微信/Telegram 通知底部的 UUID 会话标识替换为项目目录名（如 `tank-battle`）。

### 之前（用户看不懂）


### 之后（一眼就知道是哪个项目）


## 改动文件

- `crates/lucarne-wechat/src/service.rs` — `render_agent_message` 和 `render_wechat_new_session`
- `crates/lucarne-telegram/src/bot.rs` — `render_agent_notification` 和 `final_footer`

## 行为

- 用 `project_path.file_name()` 提取目录名替代 UUID
- 标签从会话改为项目
- 如果取不到目录名，fallback 到原有 UUID

Closes #43